### PR TITLE
Partner Memory changed to treat its array as a circular queue

### DIFF
--- a/Source/Scripts/Player/Player.gd
+++ b/Source/Scripts/Player/Player.gd
@@ -197,9 +197,22 @@ var partnerControlTime = DEFAULT_PLAYER2_CONTROL_TIME
 onready var defaultLayer = collision_layer
 onready var defaultMask = collision_mask
 onready var defaultZIndex = z_index
-# Input memory has 2 arrays, first is the timer, second is the input index
-# inputMemory[5][INPUT.XINPUT]
+
+# Input Memory is a circular queue backed by a 2D array. Player 2 draws from memoryPosition + 1
+# while the player inserts at memoryPosition. In effect, Player 2 is always drawing control memory
+# from the memory that was written memoryPosition frames ago.
+#
+# The first indice of the inputMemory queue is the queue position.
+# The Second indice refers to the particular input.
+#
+# Example: inputMemory[5][INPUT.XINPUT] is controller memory that was written while memoryPosition was equal to 5
+# and the specific input tracked is INPUT.XINPUT
+#
+# Note: Unless you are specifically writing something that manipulates player 2's AI control, you
+# should never need to worry about any of these details.
 var inputMemory = []
+# Used to track current position in the queue - this is where the player inserts into memory
+var memoryPosition = 0
 const INPUT_MEMORY_LENGTH = 20
 
 var Player = load("res://Entities/MainObjects/Player.tscn")
@@ -362,21 +375,19 @@ func _process(delta):
 	
 	# Player 1 input settings and partner AI
 	if playerControl == 1:
-		# Input memory
-		for i in range(INPUT_MEMORY_LENGTH-1):
-			for j in range(inputs.size()):
-				inputMemory[INPUT_MEMORY_LENGTH-1-i][j] = inputMemory[INPUT_MEMORY_LENGTH-i-2][j]
-		# set immediate inputs
+		# Input memory - write the player's input to the inputMemory queue at the current queue position
 		for i in range(inputs.size()):
-			inputMemory[0][i] = inputs[i]
-		
+			inputMemory[memoryPosition][i] = inputs[i]
+
 		# Partner ai logic
 		if partner != null:
 			# Check if partner panic
 			if partnerPanic <= 0:
 				if partner.playerControl == 0:
 					for i in partner.inputs.size():
-						partner.inputs[i] = inputMemory[INPUT_MEMORY_LENGTH-1][i]
+						# Grab the input at the position of memory minus length of the array minus one wrapping around.
+						# This should result in always grabbing memory written INPUT_MEMORY_LENGTH frames ago.
+						partner.inputs[i] = inputMemory[fposmod(memoryPosition - INPUT_MEMORY_LENGTH + 1, INPUT_MEMORY_LENGTH)][i]
 				
 				# x distance difference check, try to go to the partner
 				if (partner.inputs[INPUTS.XINPUT] == 0 and partner.inputs[INPUTS.YINPUT] == 0
@@ -402,14 +413,16 @@ func _process(delta):
 					# press action every 0.4 ticks
 					if fmod(partnerPanic,0.4)+delta > 0.4:
 						partner.inputs[INPUTS.ACTION] = 1
-					
-			
+
 			# Panic
 			# if partner is locked, and stopped then do a spindash
 			# panic for 128 frames before letting go of spindash
 			if partner.horizontalLockTimer > 0 and partner.currentState == STATES.NORMAL and global_position.distance_to(partner.global_position) > 48:
 				partnerPanic = 128/60
-				
+		
+		# Increment the memory position. Wrap back to 0 if we get to length.
+		memoryPosition = (memoryPosition + 1) % INPUT_MEMORY_LENGTH
+		
 	# respawn mechanics
 	else:
 		if $ScreenCheck.is_on_screen():

--- a/Source/Scripts/Player/Player.gd
+++ b/Source/Scripts/Player/Player.gd
@@ -428,7 +428,7 @@ func _process(delta):
 			# panic for 128 frames before letting go of spindash
 			if partner.horizontalLockTimer > 0 and partner.currentState == STATES.NORMAL and global_position.distance_to(partner.global_position) > 48:
 				partnerPanic = 128/60
-		
+
 	# respawn mechanics
 	else:
 		if $ScreenCheck.is_on_screen():


### PR DESCRIPTION
Wrote this last week, figured I wanted to go ahead and get it out of my hair.

The old way of dealing with the player memory queue was to have the player write to the end of the array after pushing all previous entries forward and to have the AI player pull from the end. That means the 20 copies of an entire INPUT array every frame. This changes that to use a circular queue -- rather than managing the array to put the data we want to read out where we want it to go and always appending to the end, we change the place where we draw from the queue. This means the only copies we need to do (regardless of the buffer length) are from the player's inputs to the input buffer and from the input buffer to the AI player's.

https://www.youtube.com/watch?v=8sjFA-IX-Ww

Here's a video on circular queues for anyone who might not understand them already. In our case, we always have the same amount of writing and reading going on, so we don't actually need to worry about tracking the current read index, only the write index since the place we are reading from will always be the one right after the one we are writing to (the first step on _ready() is to saturate the buffer with blank inputs).