### PR TITLE
Fix vertical bar/vertical pylon layer

### DIFF
--- a/Source/Entities/Gimmicks/VerticalBar.tscn
+++ b/Source/Entities/Gimmicks/VerticalBar.tscn
@@ -25,8 +25,8 @@ shape = SubResource("1")
 one_way_collision = true
 
 [node name="VerticalBarArea" type="Area2D" parent="."]
-collision_layer = 8192
-collision_mask = 0
+collision_layer = 0
+collision_mask = 4096
 script = ExtResource("2")
 
 [node name="Grab" type="AudioStreamPlayer" parent="VerticalBarArea"]

--- a/Source/Entities/Gimmicks/VerticalPylon.tscn
+++ b/Source/Entities/Gimmicks/VerticalPylon.tscn
@@ -7,6 +7,7 @@
 [sub_resource type="Animation" id="1"]
 resource_name = "main"
 length = 0.4
+loop_mode = 1
 step = 0.0166667
 tracks/0/type = "value"
 tracks/0/imported = false
@@ -50,7 +51,7 @@ _data = {
 "main": SubResource("1")
 }
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_ktifm"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_jrrgt"]
 size = Vector2(12, 96)
 
 [node name="FBZ_Pylon_Controller" type="Node2D"]
@@ -65,7 +66,7 @@ region_enabled = true
 region_rect = Rect2(0, 0, 48, 96)
 
 [node name="FBZ_Pylon_Bottom" type="Sprite2D" parent="."]
-position = Vector2(0, -7.5)
+position = Vector2(0, -8.5)
 texture = ExtResource("3")
 hframes = 3
 vframes = 2
@@ -85,12 +86,12 @@ libraries = {
 }
 
 [node name="FBZ_Pylon_Area" type="Area2D" parent="."]
-collision_layer = 4096
-collision_mask = 0
+collision_layer = 0
+collision_mask = 4096
 
 [node name="FBZ_Pylon_Collision" type="CollisionShape2D" parent="FBZ_Pylon_Area"]
 position = Vector2(0, -65)
-shape = SubResource("RectangleShape2D_ktifm")
+shape = SubResource("RectangleShape2D_jrrgt")
 
 [connection signal="body_entered" from="FBZ_Pylon_Area" to="." method="_on_FBZ_Pylon_Area_body_entered"]
 [connection signal="body_exited" from="FBZ_Pylon_Area" to="." method="_on_FBZ_Pylon_Area_body_exited"]


### PR DESCRIPTION
Also fixes a minor positional change to vertical pylon's bottom sprite piece that probably got mangled during the move to GD4. Gets animation back on vertical pylon as well.