### PR TITLE
Fix minimum jump height of underwater physics

### DIFF
--- a/Scripts/Player/States/Air.gd
+++ b/Scripts/Player/States/Air.gd
@@ -137,8 +137,8 @@ func _physics_process(delta):
 	# Mechanics if jumping
 	if (isJump):
 		# Cut vertical movement if jump released
-		if !parent.any_action_held_or_pressed() and parent.movement.y < -4*60:
-			parent.movement.y = -4*60
+		if !parent.any_action_held_or_pressed() and parent.movement.y < -parent.releaseJmp*60:
+			parent.movement.y = -parent.releaseJmp*60
 		# Drop dash (for sonic / amy)
 		if parent.character == parent.CHARACTERS.SONIC or parent.character == parent.CHARACTERS.AMY:
 			


### PR DESCRIPTION
A check in Air.gd, that cuts off the player's jump height when the jump button is released, only tested for the default jump release value without accounting for underwater physics, which caused every jump while underwater to reach maximum height. This update checks for the current jump release value to fix the problem.

This is my first PR, so I apologize if I have made any mistakes.