### PR TITLE
Various Fixes

### DIFF
--- a/Graphics/Fonts/mid_font.png.import
+++ b/Graphics/Fonts/mid_font.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/Fonts/small_font.png.import
+++ b/Graphics/Fonts/small_font.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/CardFont.png.import
+++ b/Graphics/HUD/LevelCards/font/CardFont.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/largefont1.png.import
+++ b/Graphics/HUD/LevelCards/font/largefont1.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/largefont2.png.import
+++ b/Graphics/HUD/LevelCards/font/largefont2.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/largefont3.png.import
+++ b/Graphics/HUD/LevelCards/font/largefont3.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/largefont4.png.import
+++ b/Graphics/HUD/LevelCards/font/largefont4.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/smallfont1.png.import
+++ b/Graphics/HUD/LevelCards/font/smallfont1.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/smallfont2.png.import
+++ b/Graphics/HUD/LevelCards/font/smallfont2.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/smallfont3.png.import
+++ b/Graphics/HUD/LevelCards/font/smallfont3.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/smallfont4.png.import
+++ b/Graphics/HUD/LevelCards/font/smallfont4.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/LevelCards/font/smallfont5.png.import
+++ b/Graphics/HUD/LevelCards/font/smallfont5.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/hud_lives_numerals.png.import
+++ b/Graphics/HUD/hud_lives_numerals.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Graphics/HUD/hud_numerals.png.import
+++ b/Graphics/HUD/hud_numerals.png.import
@@ -19,3 +19,4 @@ image_margin=Rect2i(0, 0, 0, 0)
 character_margin=Rect2i(0, 0, 0, 0)
 fallbacks=[]
 compress=true
+scaling_mode=0

--- a/Scripts/Gimmicks/Bridge.gd
+++ b/Scripts/Gimmicks/Bridge.gd
@@ -58,7 +58,9 @@ func _physics_process(delta):
 					elif abs(averagePlayerOffset-(global_position.x+(length/2.0*16.0))) > abs(i.global_position.x-(global_position.x+(length/2.0*16.0))):
 						averagePlayerOffset = lerp(averagePlayerOffset,i.global_position.x,0.5)
 			
+			# remove floor() if you are not making a pixel perfect game
 			$Bridge.position.y = max(floor(length/2.0)*2.0-snapped(abs(global_position.x+(length*8.0)-averagePlayerOffset)/8.0,2-int(smoothDrop)),0)
+			
 			dropIndex = max(1,floor((averagePlayerOffset-global_position.x)/16.0)+1)
 			if (dropIndex <= length/2.0):
 				maxDepression = dropIndex*2 #Working from the left
@@ -87,6 +89,7 @@ func _physics_process(delta):
 			else:
 				logDistance = 1-(difference/((length-dropIndex)+1)) # Working from the right
 			
+			# remove floor() if you are not making a pixel perfect game
 			bridges[i].position.y = lerp(bridges[i].position.y,floor(maxDepression * sin(90 * deg_to_rad(logDistance))),delta*10)
 		
 

--- a/Scripts/Gimmicks/Teleporter.gd
+++ b/Scripts/Gimmicks/Teleporter.gd
@@ -54,6 +54,7 @@ func _physics_process(delta):
 				Global.players[0].translate = false
 				# give player a bit of velocity in that direction
 				Global.players[0].movement.y = -30
+				Global.players[0].airTimer = Global.players[0].defaultAirTime
 				
 		else: #shift player by default
 			Global.players[0].global_position.y -= 30*delta
@@ -68,3 +69,5 @@ func activateBeam():
 		Global.players[0].animator.play("idle")
 		Global.players[0].groundSpeed = 60*4
 		Global.players[0].movement.x = 0
+		Global.players[0].airTimer = $BeamAnimator.current_animation_length + 30
+		

--- a/Scripts/Objects/ForceRoll.gd
+++ b/Scripts/Objects/ForceRoll.gd
@@ -3,6 +3,10 @@ extends Area2D
 var players = []
 @export_enum("left", "right") var forceDirection = 1
 
+# right now, this is handled in Player.gd so that players can't jump in the tubes
+# however, this should be done by stopping jumps under low ceilings, not like this.
+# in the case that gets properly recreated, the old behavior should be restored, thus why it's commented out.
+
 func _physics_process(_delta):
 	# if any players are found in the array, if they're on the ground make them roll
 	if players.size() > 0:
@@ -16,10 +20,13 @@ func _physics_process(_delta):
 					i.sfx[1].play()
 
 func _on_ForceRoll_body_entered(body):
-	if !players.has(body):
-		players.append(body)
+	body.forceRoll += 1
+	body.forceDirection = forceDirection
+	#if !players.has(body):
+		#players.append(body)
 
 
 func _on_ForceRoll_body_exited(body):
-	if players.has(body):
-		players.erase(body)
+	body.forceRoll -= 1
+	#if players.has(body):
+		#players.erase(body)

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -145,7 +145,7 @@ var reflective = false # used for reflecting projectiles
 @onready var animator = $Sonic/PlayerAnimation
 @onready var superAnimator = $Sonic/SuperPalette
 @onready var sprite = $Sonic/Sprite2D
-@onready var spriteControler = $Sonic
+@onready var spriteController = $Sonic
 var centerReference = null # center reference is a center reference point used for hitboxes and shields (the sprite node need a node called "CenterReference" for this to work)
 var lastActiveAnimation = ""
 var defaultSpriteOffset = Vector2.ZERO
@@ -345,7 +345,7 @@ func _ready():
 			sprite = tails.get_node("Sprite2D")
 			animator = tails.get_node("PlayerAnimation")
 			superAnimator = tails.get_node_or_null("SuperPalette")
-			spriteControler = tails
+			spriteController = tails
 			get_node("OldSprite").queue_free()
 		CHARACTERS.KNUCKLES:
 			# Set sprites
@@ -356,7 +356,7 @@ func _ready():
 			sprite = knuckles.get_node("Sprite2D")
 			animator = knuckles.get_node("PlayerAnimation")
 			superAnimator = knuckles.get_node_or_null("SuperPalette")
-			spriteControler = knuckles
+			spriteController = knuckles
 			get_node("OldSprite").queue_free()
 		CHARACTERS.AMY:
 			# Set sprites
@@ -368,7 +368,7 @@ func _ready():
 			sprite = amy.get_node("Sprite2D")
 			animator = amy.get_node("PlayerAnimation")
 			superAnimator = amy.get_node_or_null("SuperPalette")
-			spriteControler = amy
+			spriteController = amy
 			get_node("OldSprite").queue_free()
 			maxCharGroundHeight = 12 # adjust height distance to prevent clipping off floors (amy's smaller)
 			
@@ -384,7 +384,7 @@ func _ready():
 	defaultSpriteOffset = sprite.offset
 	
 	# set secondary hitboxes
-	crouchBox = spriteControler.get_node_or_null("CrouchBox")
+	crouchBox = spriteController.get_node_or_null("CrouchBox")
 	if crouchBox != null:
 		crouchBox.get_parent().remove_child(crouchBox)
 		add_child(crouchBox)
@@ -392,7 +392,7 @@ func _ready():
 		hitBoxOffset.crouch = crouchBox.position
 	
 	# add center reference node
-	centerReference = spriteControler.get_node_or_null("CenterReference")
+	centerReference = spriteController.get_node_or_null("CenterReference")
 	# hide reference
 	if centerReference:
 		centerReference.visible = false
@@ -503,7 +503,7 @@ func _process(delta):
 	else:
 		sprite.rotation = -rotation+gravityAngle
 
-	spriteControler.global_position = global_position.round()
+	spriteController.global_position = global_position.round()
 
 	# Sprite center offset referencing for shields
 	if centerReference != null:

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -41,6 +41,10 @@ var panicTime = 12 # start count down at 12 seconds
 var airWarning = 5 # time between air meter sound
 var airTimer = defaultAirTime
 
+# force roll variables
+var forceRoll = 0 # each force roll object the player is in, this increments.
+var forceDirection = 0
+
 # collision related values
 var pushingWall = 0
 
@@ -644,6 +648,14 @@ func _process(delta):
 
 func _physics_process(delta):
 	super(delta)
+	
+	if ground and forceRoll > 0:
+		if (movement*Vector2(1,0)).is_equal_approx(Vector2.ZERO):
+			movement.x = 2*sign(-1+(forceDirection*2))*60.0
+		if currentState != STATES.ROLL:
+			set_state(STATES.ROLL)
+			animator.play("roll")
+			sfx[1].play()
 	
 	# Attacking is for rolling type animations
 	var attacking = false
@@ -1354,15 +1366,16 @@ func action_move(delta):
 				movement.x -= movement.x
 
 func action_jump(animation = "roll", airJumpControl = true, playSound=true):
-	animator.play(animation)
-	animator.advance(0)
-	movement.y = -jmp
-	if playSound:
-		sfx[0].play()
-	airControl = airJumpControl
-	cameraDragLerp = 1
-	disconect_from_floor()
-	set_state(STATES.JUMP)
+	if forceRoll <= 0: # check to prevent jumping in roll tubes
+		animator.play(animation)
+		animator.advance(0)
+		movement.y = -jmp
+		if playSound:
+			sfx[0].play()
+		airControl = airJumpControl
+		cameraDragLerp = 1
+		disconect_from_floor()
+		set_state(STATES.JUMP)
 
 func emit_enemy_bounce():
 	emit_signal("enemy_bounced")

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -509,9 +509,8 @@ func _process(delta):
 	if centerReference != null:
 		shieldSprite.global_position = centerReference.global_position
 
-	if (horizontalLockTimer > 0):
+	if (horizontalLockTimer > 0 and ground):
 		horizontalLockTimer -= delta
-		inputs[INPUTS.XINPUT] = 0
 
 	# super / invincibility handling
 	if (supTime > 0):
@@ -881,8 +880,6 @@ func set_inputs():
 		inputs[INPUTS.ACTION2] = (int(Input.is_action_pressed(inputActions[INPUTS.ACTION2]))*2)-int(Input.is_action_just_pressed(inputActions[INPUTS.ACTION2]))
 		inputs[INPUTS.ACTION3] =  (int(Input.is_action_pressed(inputActions[INPUTS.ACTION3]))*2)-int(Input.is_action_just_pressed(inputActions[INPUTS.ACTION3]))
 		inputs[INPUTS.SUPER] =  (int(Input.is_action_pressed(inputActions[INPUTS.SUPER]))*2)-int(Input.is_action_just_pressed(inputActions[INPUTS.SUPER]))
-	
-	if (playerControl > 0 and horizontalLockTimer <= 0):
 		inputs[INPUTS.XINPUT] = -int(Input.is_action_pressed(inputActions[INPUTS.XINPUT][0]))+int(Input.is_action_pressed(inputActions[INPUTS.XINPUT][1]))
 		inputs[INPUTS.YINPUT] = -int(Input.is_action_pressed(inputActions[INPUTS.YINPUT][0]))+int(Input.is_action_pressed(inputActions[INPUTS.YINPUT][1]))
 
@@ -1334,18 +1331,19 @@ func _on_BubbleTimer_timeout():
 func action_move(delta):
 	# moving left and right, check if left or right is being pressed
 	if inputs[INPUTS.XINPUT] != 0:
-		# check if movement is less then the top speed
-		if movement.x*inputs[INPUTS.XINPUT] < top:
-			# check if the player is pressing the direction they're moving
-			if sign(movement.x) == inputs[INPUTS.XINPUT] or sign(movement.x) == 0:
-				if abs(movement.x) < top:
-					movement.x = move_toward(movement.x,top*inputs[INPUTS.XINPUT],acc/GlobalFunctions.div_by_delta(delta))
-			else:
-				# reverse direction
-				movement.x += dec/GlobalFunctions.div_by_delta(delta)*inputs[INPUTS.XINPUT]
-				# implament weird turning quirk
-				if (sign(movement.x) != sign(movement.x-dec/GlobalFunctions.div_by_delta(delta)*inputs[INPUTS.XINPUT])):
-					movement.x = 0.5*60*sign(movement.x)
+		if horizontalLockTimer <= 0: # skip logic if lock timer is around, friction gets skipped too since the original games worked like that
+			# check if movement is less then the top speed
+			if movement.x*inputs[INPUTS.XINPUT] < top:
+				# check if the player is pressing the direction they're moving
+				if sign(movement.x) == inputs[INPUTS.XINPUT] or sign(movement.x) == 0:
+					if abs(movement.x) < top:
+						movement.x = move_toward(movement.x,top*inputs[INPUTS.XINPUT],acc/GlobalFunctions.div_by_delta(delta))
+				else:
+					# reverse direction
+					movement.x += dec/GlobalFunctions.div_by_delta(delta)*inputs[INPUTS.XINPUT]
+					# implament weird turning quirk
+					if (sign(movement.x) != sign(movement.x-dec/GlobalFunctions.div_by_delta(delta)*inputs[INPUTS.XINPUT])):
+						movement.x = 0.5*60*sign(movement.x)
 	else:
 		# come to a stop if neither left or right is pressed
 		if (movement.x != 0):

--- a/Scripts/Player/States/Normal.gd
+++ b/Scripts/Player/States/Normal.gd
@@ -226,12 +226,11 @@ func _physics_process(delta):
 	if (calcAngle < 0):
 		calcAngle += 360
 	
-	# if speed below fall speed, either drop or slide down slopes
+	# if speed below fall speed, slide down slopes and maybe also drop
 	if (abs(parent.movement.x) < parent.fall and calcAngle >= 45 and calcAngle <= 315):
 		if (round(calcAngle) >= 90 and round(calcAngle) <= 270):
 			parent.disconect_from_floor()
-		else:
-			parent.horizontalLockTimer = 30.0/60.0
+		parent.horizontalLockTimer = 30.0/60.0
 		
 	# movement
 	parent.action_move(delta)

--- a/Scripts/Player/States/Roll.gd
+++ b/Scripts/Player/States/Roll.gd
@@ -7,7 +7,6 @@ func _process(_delta):
 		# use parent.action_jump("roll",false) to have jump lock similar to sonic 1-3
 		# true replicates CD and Mania
 		parent.action_jump("roll",true)
-		parent.set_state(parent.STATES.JUMP)
 	# water running
 	parent.action_water_run_handle()
 

--- a/project.godot
+++ b/project.godot
@@ -230,6 +230,7 @@ ui_reset={
 textures/canvas_textures/default_texture_filter=0
 textures/canvas_textures/default_texture_repeat=1
 renderer/rendering_method="gl_compatibility"
+2d/snap/snap_2d_vertices_to_pixel=true
 environment/defaults/default_environment="res://default_env.tres"
 2d/snapping/use_gpu_pixel_snap=true
 batching/precision/uv_contract=true


### PR DESCRIPTION
Fonts currently try to do some weird scaling nonsense and end up twice as big.

This disables all fonts' scaling in their import settings to replicate the old sprite-based behavior of... not doing that.
As far as I know this has been an issue for a while, and chances are it might be system dependent or something like that if the team hasn't seen the problem yet.
I haven't tested much at all, but usually godot's usual exports are supposed to represent debug pretty well.

Also spriteController is properly named, not that it's used that much here, but it was annoying in CC.

edit: This later expanded as an overall fixing, so here's a changelog instead.
- Fonts got fixed... probably
- Character Select no longer has strange scaling behavior on the character sprites due to a project setting
- spriteControler variable has an extra l
- horizontalLockTimer's function has been modified to more closely resemble the [Sonic Physics Guide](https://info.sonicretro.org/SPG:Slope_Physics)
- Fixed reported wall zipping when jumping off an edge in a very specific way
- You can't drown in the teleporter anymore
- Bridges now have comments to remove floor() if you're not making a pixel perfect game.
- Added a temporary fix for the player being able to jump inside of tubes.