### PR TITLE
Fix rings animating while game is paused

### DIFF
--- a/Entities/Items/Ring.tscn
+++ b/Entities/Items/Ring.tscn
@@ -34,6 +34,7 @@ z_index = 1
 script = ExtResource("1")
 
 [node name="RingSprite" type="AnimatedSprite2D" parent="."]
+process_mode = 1
 z_index = 4
 sprite_frames = SubResource("2")
 autoplay = "default"


### PR DESCRIPTION
Super simple fix for #169. Seems to just be a weird quirk with the AnimatedSprite2D node in general.