### PR TITLE
Caverns 4 tests

### DIFF
--- a/Scripts/Objects/Ring.gd
+++ b/Scripts/Objects/Ring.gd
@@ -55,11 +55,13 @@ func _physics_process(delta):
 			scattered = true
 		#"ringacceleration" would be an array, where: [0] = 0.75 [1] = 0.1875
 		
-		
 
 func _on_Hitbox_body_entered(body):
 	if (player != body):
-		player = body
+		# The check below exists to prevent potential undesirable behavior where a partner
+		# can immediatelly recollect all lost rings as soon as the leader is hurt.
+		if (!scattered) or (scattered and lifetime < (3.3)):
+			player = body
 
 
 func _on_Hitbox_body_exited(body):

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -478,7 +478,7 @@ func _process(delta):
 			sprite.rotation = deg_to_rad(snapped(spriteRotation,45)-90)-rotation-gravityAngle
 		else:
 			sprite.rotation = -rotation-gravityAngle
-		# uncomment this next line out for smooth rotation (you should remove the above line too)
+		# uncomment the line below and comment the line above for smooth rotation
 		#sprite.rotation = deg_to_rad(spriteRotation-90)-rotation-gravityAngle
 	else:
 		sprite.rotation = -rotation+gravityAngle

--- a/Scripts/Player/TailsAnimator.gd
+++ b/Scripts/Player/TailsAnimator.gd
@@ -16,13 +16,13 @@ func _process(_delta):
 			if player:
 				if player.ground:
 					global_rotation = deg_to_rad(snapped(rad_to_deg(player.angle),45))-player.gravityAngle
-					# uncomment below for smooth rotation
+					# uncomment the line below and comment the line above for smooth rotation
 					#global_rotation = player.angle-player.gravityAngle
 					if sign(player.movement.x) != 0:
 						scale = Vector2(sign(player.movement.x),1)
 				else:
 					global_rotation = deg_to_rad(snapped(rad_to_deg(player.movement.angle()),45))-player.gravityAngle
-					# uncomment below for smooth rotation
+					# uncomment the line below and comment the line above for smooth rotation
 					#global_rotation = player.movement.angle()-player.gravityAngle
 					scale = Vector2(1,1-(int(rad_to_deg(rotation) > 90 and rad_to_deg(rotation) < 270)*2))
 				


### PR DESCRIPTION
This isn't *strictly* accurate to the genesis games, but I feel is probably more desirable behavior.
When the player loses ring while a partner is in the same spot as them, the partner AI will get hit after the leader, resulting in all lost rings immediately get collected in one frame.
This change applies a cooldown time of a little under 1 second to prevent this behavior. The result feels much more intended.