### PR TITLE
Genesis-accurate hit mechanics.

### DIFF
--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -541,7 +541,7 @@ func _process(delta):
 		if (invTime <= 0):
 			invTime = 0
 			visible = true
-	if (ringDisTime > 0):
+	if (ringDisTime > 0) and currentState != STATES.HIT:
 		ringDisTime -= delta
 
 	# Rings 1up
@@ -1022,11 +1022,11 @@ func hit_player(damagePoint = global_position, damageType = 0, soundID = 6):
 
 		disconect_from_floor()
 		set_state(STATES.HIT)
-		invTime = 120
+		invTime = 120 # Ivulnerable for 2 seconds. Starts counting *after* landing.
 		# Ring loss
 		if (shield == SHIELDS.NONE and rings > 0 and playerControl == 1):
 			sfx[9].play()
-			ringDisTime = 64.0/60.0 # ignore rings for 64 frames
+			ringDisTime = 30.0/60.0 # ignore rings for 30 frames after landing
 			var ringCount = 0
 			var ringAngle = 101.25
 			var ringAlt = false


### PR DESCRIPTION
Ring ignore timer does not count down until landing, and was previously far too long to compensate.