### PR TITLE
Fixes and adjustments for character select menu

### DIFF
--- a/Scene/Presentation/CharacterSelect.tscn
+++ b/Scene/Presentation/CharacterSelect.tscn
@@ -73,6 +73,42 @@ tracks/4/keys = {
 "update": 1,
 "values": [Rect2(488, 8, 32, 40), Rect2(536, 8, 32, 40), Rect2(584, 8, 32, 40), Rect2(536, 8, 32, 40)]
 }
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("SonicAndTails/Sonic:region_rect")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0, 0.25, 0.5, 0.75),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 1,
+"values": [Rect2(731, 9, 24, 39), Rect2(683, 9, 24, 39), Rect2(731, 9, 24, 39), Rect2(683, 9, 24, 39)]
+}
+tracks/6/type = "value"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("SonicAndTails/Tails:region_rect")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [Rect2(672, 200, 40, 40), Rect2(720, 200, 40, 40)]
+}
+tracks/7/type = "value"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath("SonicAndTails/Tails/TailsTails:region_rect")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [Rect2(488, 25, 16, 22), Rect2(534, 26, 19, 21), Rect2(580, 30, 20, 18), Rect2(628, 32, 20, 16), Rect2(677, 28, 19, 20), Rect2(488, 25, 16, 22), Rect2(534, 26, 19, 21), Rect2(580, 30, 20, 18), Rect2(628, 32, 20, 16), Rect2(677, 28, 19, 20)]
+}
 
 [sub_resource type="Animation" id="2"]
 length = 0.001
@@ -136,6 +172,42 @@ tracks/4/keys = {
 "update": 0,
 "values": [Rect2(488, 8, 32, 40)]
 }
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("SonicAndTails/Sonic:region_rect")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Rect2(731, 9, 24, 39)]
+}
+tracks/6/type = "value"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("SonicAndTails/Tails:region_rect")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Rect2(676, 205, 33, 35)]
+}
+tracks/7/type = "value"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath("SonicAndTails/Tails/TailsTails:region_rect")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Rect2(488, 25, 16, 22)]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_wio08"]
 _data = {
@@ -174,16 +246,40 @@ grow_vertical = 2
 [node name="CharacterOrigin" type="Node2D" parent="UI/Labels"]
 position = Vector2(160, 97)
 
-[node name="Sonic" type="Sprite2D" parent="UI/Labels/CharacterOrigin"]
+[node name="SonicAndTails" type="Node2D" parent="UI/Labels/CharacterOrigin"]
+
+[node name="Sonic" type="Sprite2D" parent="UI/Labels/CharacterOrigin/SonicAndTails"]
 z_index = 3
-position = Vector2(6, 0)
+position = Vector2(10, 0)
+texture = ExtResource("1")
+region_enabled = true
+region_rect = Rect2(731, 9, 24, 39)
+
+[node name="Tails" type="Sprite2D" parent="UI/Labels/CharacterOrigin/SonicAndTails"]
+z_index = 2
+position = Vector2(-10, 0)
+texture = ExtResource("4")
+region_enabled = true
+region_rect = Rect2(676, 205, 33, 35)
+
+[node name="TailsTails" type="Sprite2D" parent="UI/Labels/CharacterOrigin/SonicAndTails/Tails"]
+z_index = -1
+position = Vector2(-9, 7)
+texture = ExtResource("4")
+region_enabled = true
+region_rect = Rect2(488, 25, 16, 22)
+
+[node name="Sonic" type="Sprite2D" parent="UI/Labels/CharacterOrigin"]
+visible = false
+z_index = 3
+position = Vector2(-1, 0)
 texture = ExtResource("1")
 region_enabled = true
 region_rect = Rect2(731, 9, 24, 39)
 
 [node name="Tails" type="Sprite2D" parent="UI/Labels/CharacterOrigin"]
+visible = false
 z_index = 2
-position = Vector2(-14, 0)
 texture = ExtResource("4")
 region_enabled = true
 region_rect = Rect2(676, 205, 33, 35)
@@ -198,7 +294,7 @@ region_rect = Rect2(488, 25, 16, 22)
 [node name="Knuckles" type="Sprite2D" parent="UI/Labels/CharacterOrigin"]
 visible = false
 z_index = 3
-position = Vector2(-3, 0)
+position = Vector2(0, 2)
 texture = ExtResource("7")
 region_enabled = true
 region_rect = Rect2(252, 17, 32, 39)
@@ -206,7 +302,7 @@ region_rect = Rect2(252, 17, 32, 39)
 [node name="Amy" type="Sprite2D" parent="UI/Labels/CharacterOrigin"]
 visible = false
 z_index = 3
-position = Vector2(-5, 3)
+position = Vector2(1, 3)
 texture = ExtResource("6_nah0p")
 region_enabled = true
 region_rect = Rect2(488, 8, 32, 40)

--- a/Scene/Presentation/CharacterSelect.tscn
+++ b/Scene/Presentation/CharacterSelect.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://c4e1wv2sxs1gm"]
+[gd_scene load_steps=13 format=3 uid="uid://c4e1wv2sxs1gm"]
 
 [ext_resource type="Texture2D" uid="uid://4lhg0ovh1pe8" path="res://Graphics/Players/Sonic.png" id="1"]
 [ext_resource type="Texture2D" uid="uid://bemwlrblbgn23" path="res://Graphics/Backgrounds/WorldsBackground.png" id="2"]
@@ -8,6 +8,7 @@
 [ext_resource type="Texture2D" uid="uid://bfesqgvh63scg" path="res://Graphics/Players/Amy.png" id="6_nah0p"]
 [ext_resource type="Texture2D" uid="uid://cndrds5482vh5" path="res://Graphics/Players/Knuckles.png" id="7"]
 [ext_resource type="Texture2D" uid="uid://dhygmoxun35w1" path="res://Graphics/Fonts/arrows_small_font.png" id="9"]
+[ext_resource type="AudioStream" uid="uid://dh4rsaka62ph4" path="res://Audio/SFX/Gimmicks/Switch.wav" id="9_5f42f"]
 
 [sub_resource type="Animation" id="1"]
 resource_name = "Animate"
@@ -375,3 +376,7 @@ anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color(1, 1, 1, 0)
+
+[node name="Switch" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("9_5f42f")
+bus = &"SFX"

--- a/Scripts/Level/CharacterSelect.gd
+++ b/Scripts/Level/CharacterSelect.gd
@@ -30,15 +30,16 @@ func _input(event):
 		var inputCue = Input.get_vector("gm_left","gm_right","gm_up","gm_down")
 		inputCue.x = round(inputCue.x)
 		inputCue.y = round(inputCue.y)
-		if inputCue != lastInput:
+		if inputCue.x != lastInput.x:
 			# select character rotation
 			if inputCue.x < 0:
 				characterID = wrapi(characterID-1,0,characterLabels.size())
-			if inputCue.x > 0:
+			elif inputCue.x > 0:
 				characterID = wrapi(characterID+1,0,characterLabels.size())
+		if inputCue.y != lastInput.y:
 			if inputCue.y > 0:
 				levelID = wrapi(levelID+1,0,levelLabels.size())
-			if inputCue.y < 0:
+			elif inputCue.y < 0:
 				levelID = wrapi(levelID-1,0,levelLabels.size())
 		#Save previous input for next read
 		lastInput = inputCue

--- a/Scripts/Level/CharacterSelect.gd
+++ b/Scripts/Level/CharacterSelect.gd
@@ -10,7 +10,8 @@ var characterLabels = ["Sonic and Tails", "Sonic", "Tails", "Knuckles", "Amy"]
 # level labels, the amount of labels in here determines the total amount of options, see set level option at the end for settings
 var levelLabels = ["Base Zone Act 1", "Base Zone Act 2"]#, "Chunk Zone Act 1"]
 # character id lines up with characterLabels
-var characterID = 0
+enum CHARACTER_ID { SONIC_AND_TAILS, SONIC, TAILS, KNUCKLES, AMY }
+var characterID = CHARACTER_ID.SONIC_AND_TAILS
 # level id lines up with levelLabels
 var levelID = 0
 # Used to avoid repeated detection of inputs with analog stick
@@ -33,9 +34,9 @@ func _input(event):
 		if inputCue.x != lastInput.x:
 			# select character rotation
 			if inputCue.x < 0:
-				characterID = wrapi(characterID-1,0,characterLabels.size())
+				characterID = wrapi(characterID-1,0,characterLabels.size()) as CHARACTER_ID
 			elif inputCue.x > 0:
-				characterID = wrapi(characterID+1,0,characterLabels.size())
+				characterID = wrapi(characterID+1,0,characterLabels.size()) as CHARACTER_ID
 		if inputCue.y != lastInput.y:
 			if inputCue.y > 0:
 				levelID = wrapi(levelID+1,0,levelLabels.size())
@@ -49,27 +50,27 @@ func _input(event):
 		
 		# turn on and off visibility of the characters based on the current selection
 		match(characterID):
-			0: # Sonic and Tails
+			CHARACTER_ID.SONIC_AND_TAILS:
 				$UI/Labels/CharacterOrigin/Sonic.visible = true
 				$UI/Labels/CharacterOrigin/Tails.visible = true
 				$UI/Labels/CharacterOrigin/Knuckles.visible = false
 				$UI/Labels/CharacterOrigin/Amy.visible = false
-			1: # Sonic
+			CHARACTER_ID.SONIC:
 				$UI/Labels/CharacterOrigin/Sonic.visible = true
 				$UI/Labels/CharacterOrigin/Tails.visible = false
 				$UI/Labels/CharacterOrigin/Knuckles.visible = false
 				$UI/Labels/CharacterOrigin/Amy.visible = false
-			2: # Tails
+			CHARACTER_ID.TAILS:
 				$UI/Labels/CharacterOrigin/Sonic.visible = false
 				$UI/Labels/CharacterOrigin/Tails.visible = true
 				$UI/Labels/CharacterOrigin/Knuckles.visible = false
 				$UI/Labels/CharacterOrigin/Amy.visible = false
-			3: # Knuckles
+			CHARACTER_ID.KNUCKLES:
 				$UI/Labels/CharacterOrigin/Sonic.visible = false
 				$UI/Labels/CharacterOrigin/Tails.visible = false
 				$UI/Labels/CharacterOrigin/Knuckles.visible = true
 				$UI/Labels/CharacterOrigin/Amy.visible = false
-			4: # Amy
+			CHARACTER_ID.AMY:
 				$UI/Labels/CharacterOrigin/Sonic.visible = false
 				$UI/Labels/CharacterOrigin/Tails.visible = false
 				$UI/Labels/CharacterOrigin/Knuckles.visible = false
@@ -83,16 +84,16 @@ func _input(event):
 			
 			# set the character
 			match(characterID):
-				0: # Sonic and Tails
+				CHARACTER_ID.SONIC_AND_TAILS:
 					Global.PlayerChar1 = Global.CHARACTERS.SONIC
 					Global.PlayerChar2 = Global.CHARACTERS.TAILS
-				1: # Sonic
+				CHARACTER_ID.SONIC:
 					Global.PlayerChar1 = Global.CHARACTERS.SONIC
-				2: # Tails
+				CHARACTER_ID.TAILS:
 					Global.PlayerChar1 = Global.CHARACTERS.TAILS
-				3: # Knuckles
+				CHARACTER_ID.KNUCKLES:
 					Global.PlayerChar1 = Global.CHARACTERS.KNUCKLES
-				4: # Amy
+				CHARACTER_ID.AMY:
 					Global.PlayerChar1 = Global.CHARACTERS.AMY
 					
 			# set the level

--- a/Scripts/Level/CharacterSelect.gd
+++ b/Scripts/Level/CharacterSelect.gd
@@ -14,6 +14,8 @@ enum CHARACTER_ID { SONIC_AND_TAILS, SONIC, TAILS, KNUCKLES, AMY }
 var characterID = CHARACTER_ID.SONIC_AND_TAILS
 # level id lines up with levelLabels
 var levelID = 0
+# Used to toggle visibility of character sprites (initialized in `_ready()`)
+var characterSprites = []
 # Used to avoid repeated detection of inputs with analog stick
 var lastInput = Vector2.ZERO
 
@@ -24,6 +26,12 @@ func _ready():
 	$UI/Labels/Control/Character.text = characterLabels[characterID]
 	if nextZone != null:
 		Global.nextZone = nextZone
+
+	for child in $UI/Labels/CharacterOrigin.get_children():
+		if child is Node2D or child is Sprite2D:
+			characterSprites.append(child)
+	assert(characterLabels.size() == characterSprites.size())
+	assert(characterLabels.size() == CHARACTER_ID.size())
 
 func _input(event):
 	
@@ -49,37 +57,8 @@ func _input(event):
 		$UI/Labels/Control/Level.text = levelLabels[levelID]
 		
 		# turn on and off visibility of the characters based on the current selection
-		match(characterID):
-			CHARACTER_ID.SONIC_AND_TAILS:
-				$UI/Labels/CharacterOrigin/SonicAndTails.visible = true
-				$UI/Labels/CharacterOrigin/Sonic.visible = false
-				$UI/Labels/CharacterOrigin/Tails.visible = false
-				$UI/Labels/CharacterOrigin/Knuckles.visible = false
-				$UI/Labels/CharacterOrigin/Amy.visible = false
-			CHARACTER_ID.SONIC:
-				$UI/Labels/CharacterOrigin/SonicAndTails.visible = false
-				$UI/Labels/CharacterOrigin/Sonic.visible = true
-				$UI/Labels/CharacterOrigin/Tails.visible = false
-				$UI/Labels/CharacterOrigin/Knuckles.visible = false
-				$UI/Labels/CharacterOrigin/Amy.visible = false
-			CHARACTER_ID.TAILS:
-				$UI/Labels/CharacterOrigin/SonicAndTails.visible = false
-				$UI/Labels/CharacterOrigin/Sonic.visible = false
-				$UI/Labels/CharacterOrigin/Tails.visible = true
-				$UI/Labels/CharacterOrigin/Knuckles.visible = false
-				$UI/Labels/CharacterOrigin/Amy.visible = false
-			CHARACTER_ID.KNUCKLES:
-				$UI/Labels/CharacterOrigin/SonicAndTails.visible = false
-				$UI/Labels/CharacterOrigin/Sonic.visible = false
-				$UI/Labels/CharacterOrigin/Tails.visible = false
-				$UI/Labels/CharacterOrigin/Knuckles.visible = true
-				$UI/Labels/CharacterOrigin/Amy.visible = false
-			CHARACTER_ID.AMY:
-				$UI/Labels/CharacterOrigin/SonicAndTails.visible = false
-				$UI/Labels/CharacterOrigin/Sonic.visible = false
-				$UI/Labels/CharacterOrigin/Tails.visible = false
-				$UI/Labels/CharacterOrigin/Knuckles.visible = false
-				$UI/Labels/CharacterOrigin/Amy.visible = true
+		for i in characterSprites.size():
+			characterSprites[i].visible = (characterID == i)
 		
 		# finish character select if start is pressed
 		if event.is_action_pressed("gm_pause"):

--- a/Scripts/Level/CharacterSelect.gd
+++ b/Scripts/Level/CharacterSelect.gd
@@ -39,17 +39,19 @@ func _input(event):
 		var inputCue = Input.get_vector("gm_left","gm_right","gm_up","gm_down")
 		inputCue.x = round(inputCue.x)
 		inputCue.y = round(inputCue.y)
-		if inputCue.x != lastInput.x:
+		if inputCue.x != lastInput.x and inputCue.x != 0:
 			# select character rotation
 			if inputCue.x < 0:
 				characterID = wrapi(characterID-1,0,characterLabels.size()) as CHARACTER_ID
-			elif inputCue.x > 0:
+			else: # inputCue.x > 0
 				characterID = wrapi(characterID+1,0,characterLabels.size()) as CHARACTER_ID
-		if inputCue.y != lastInput.y:
+			$Switch.play()
+		if inputCue.y != lastInput.y and inputCue.y != 0:
 			if inputCue.y > 0:
 				levelID = wrapi(levelID+1,0,levelLabels.size())
-			elif inputCue.y < 0:
+			else: # inputCue.y < 0
 				levelID = wrapi(levelID-1,0,levelLabels.size())
+			$Switch.play()
 		#Save previous input for next read
 		lastInput = inputCue
 		

--- a/Scripts/Level/CharacterSelect.gd
+++ b/Scripts/Level/CharacterSelect.gd
@@ -51,26 +51,31 @@ func _input(event):
 		# turn on and off visibility of the characters based on the current selection
 		match(characterID):
 			CHARACTER_ID.SONIC_AND_TAILS:
-				$UI/Labels/CharacterOrigin/Sonic.visible = true
-				$UI/Labels/CharacterOrigin/Tails.visible = true
+				$UI/Labels/CharacterOrigin/SonicAndTails.visible = true
+				$UI/Labels/CharacterOrigin/Sonic.visible = false
+				$UI/Labels/CharacterOrigin/Tails.visible = false
 				$UI/Labels/CharacterOrigin/Knuckles.visible = false
 				$UI/Labels/CharacterOrigin/Amy.visible = false
 			CHARACTER_ID.SONIC:
+				$UI/Labels/CharacterOrigin/SonicAndTails.visible = false
 				$UI/Labels/CharacterOrigin/Sonic.visible = true
 				$UI/Labels/CharacterOrigin/Tails.visible = false
 				$UI/Labels/CharacterOrigin/Knuckles.visible = false
 				$UI/Labels/CharacterOrigin/Amy.visible = false
 			CHARACTER_ID.TAILS:
+				$UI/Labels/CharacterOrigin/SonicAndTails.visible = false
 				$UI/Labels/CharacterOrigin/Sonic.visible = false
 				$UI/Labels/CharacterOrigin/Tails.visible = true
 				$UI/Labels/CharacterOrigin/Knuckles.visible = false
 				$UI/Labels/CharacterOrigin/Amy.visible = false
 			CHARACTER_ID.KNUCKLES:
+				$UI/Labels/CharacterOrigin/SonicAndTails.visible = false
 				$UI/Labels/CharacterOrigin/Sonic.visible = false
 				$UI/Labels/CharacterOrigin/Tails.visible = false
 				$UI/Labels/CharacterOrigin/Knuckles.visible = true
 				$UI/Labels/CharacterOrigin/Amy.visible = false
 			CHARACTER_ID.AMY:
+				$UI/Labels/CharacterOrigin/SonicAndTails.visible = false
 				$UI/Labels/CharacterOrigin/Sonic.visible = false
 				$UI/Labels/CharacterOrigin/Tails.visible = false
 				$UI/Labels/CharacterOrigin/Knuckles.visible = false


### PR DESCRIPTION
This PR does the following:
* Fixes X and Y inputs overlapping when  `↑`/ `↓` and `←`/`→` buttons are pressed at the same time.
  How to reprocuce the bug:
  1. In Character Select press and hold the `→` button. Currently selected character will switch forward from  "Sonic and Tails" to "Sonic".
  2. Press the `↓` button (while still holding the `→` button). The level will switch to "Base Zone Act 2", but since the `→` button is still being pressed, the character will also switch to "Tails", as if the button was released and pressed again.
  3. Release the `↓` button (with the `→` button still being pressed). The character will again switch to "Knuckles".
* Minor cosmetic fixes for more polished look:
  * Use named constants for character IDs, as hardcoding them isn't a good practice.
  * Improved centering of character sprites on the screen.
    I had to duplicate Sonic's and Tails' sprites for this (one pair of sprites for "Sonic and Tails", and the other for "Sonic" and "Tails" alone each; copied Tails' tails too), as changing their coordinates via scripting (and hardcoding their coordinates in the code) wouldn't look as good. 
    This also allowed me to remove some repetitive code.
  * Play switch sound when changing character and level selection.