### PR TITLE
Player doesn't jump when there's no room to.

### DIFF
--- a/Scripts/Objects/PhysicsObject.gd
+++ b/Scripts/Objects/PhysicsObject.gd
@@ -427,3 +427,20 @@ func push_vertical():
 			position += (rayHitVec-(normHitVec*(($HitBox.shape.size.y/2)+0.25))-Vector2(0,yGroundDiff).rotated(rotation))
 	# reset movement
 	movement = movementMemory
+
+# Return true if there is a ceiling above the object based on its y size.
+func check_for_ceiling():
+	var detection = false
+	# Create and set up a temporary Raycast
+	var ceilChecker = RayCast2D.new()
+	$HitBox.add_child(ceilChecker)
+	ceilChecker.collision_mask = 2184
+	ceilChecker.target_position.y = 0-verticalSensorLeft.target_position.y
+	ceilChecker.force_raycast_update()
+	# Check is there's a collision
+	if ceilChecker.is_colliding() or ceilChecker.is_colliding():
+		detection = true
+	# Flag the new Rcast for clearance.
+	ceilChecker.queue_free()
+	# Return the detection value
+	return detection

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -873,14 +873,12 @@ func set_inputs():
 
 # Controller scan functions -- so you don't have to dig into the inputs to check controller state
 func any_action_pressed():
-	if inputs[INPUTS.ACTION] == 1:
-		return true
-	if inputs[INPUTS.ACTION2] == 1:
-		return true
-	if inputs[INPUTS.ACTION3] == 1:
+	if (inputs[INPUTS.ACTION] == 1
+	or inputs[INPUTS.ACTION2] == 1 or
+	inputs[INPUTS.ACTION3] == 1):
 		return true
 	return false
-		
+
 func any_action_held():
 	if inputs[INPUTS.ACTION] == 2:
 		return true
@@ -889,7 +887,7 @@ func any_action_held():
 	if inputs[INPUTS.ACTION3] == 2:
 		return true
 	return false
-		
+
 func any_action_held_or_pressed():
 	if inputs[INPUTS.ACTION] > 0:
 		return true

--- a/Scripts/Player/States/Normal.gd
+++ b/Scripts/Player/States/Normal.gd
@@ -50,10 +50,12 @@ func _process(delta):
 			parent.spindashPower = 0
 			parent.set_state(parent.STATES.PEELOUT)
 		else:
-			# reset animations
-			parent.animator.play("RESET")
-			parent.action_jump()
-			parent.set_state(parent.STATES.JUMP)
+			# Player cannot jump unless a ceiling check fails.
+			if !parent.check_for_ceiling():
+				# reset animations
+				parent.animator.play("RESET")
+				parent.action_jump()
+				parent.set_state(parent.STATES.JUMP)
 		return null
 	
 	if parent.ground and !skid:

--- a/Scripts/Player/States/Roll.gd
+++ b/Scripts/Player/States/Roll.gd
@@ -3,7 +3,8 @@ extends PlayerState
 
 
 func _process(_delta):
-	if parent.inputs[parent.INPUTS.ACTION] == 1 or parent.inputs[parent.INPUTS.ACTION2] == 1 or parent.inputs[parent.INPUTS.ACTION3] == 1:
+	# Player cannot jump unless a ceiling check fails.
+	if parent.any_action_pressed() and !parent.check_for_ceiling():
 		# use parent.action_jump("roll",false) to have jump lock similar to sonic 1-3
 		# true replicates CD and Mania
 		parent.action_jump("roll",true)


### PR DESCRIPTION
Players are not supposed to be able to jump when there simply isn't room to do so. Added a new Physics Object function that creates a temporary Raycast, scans for a ceiling, and returns true or false. Normal and Roll scripts have been updated to perform this check, and roll.gd now uses any_action_pressed(), making the code a little cleaner to read.