### PR TITLE
Adjust the position of game window when resizing it

### DIFF
--- a/Scripts/Global/Global.gd
+++ b/Scripts/Global/Global.gd
@@ -207,7 +207,10 @@ func load_settings():
 	
 	if file.has_section_key("Resolution","Zoom"):
 		zoomSize = file.get_value("Resolution","Zoom")
-		get_window().set_size(get_viewport().get_visible_rect().size*zoomSize)
+		var window = get_window()
+		var newSize = Vector2i((get_viewport().get_visible_rect().size*zoomSize).round())
+		window.set_position(window.get_position()+(window.size-newSize)/2)
+		window.set_size(newSize)
 	
 	if file.has_section_key("Resolution","FullScreen"):
 		get_window().mode = Window.MODE_EXCLUSIVE_FULLSCREEN if (file.get_value("Resolution","FullScreen")) else Window.MODE_WINDOWED

--- a/Scripts/Misc/PauseManager.gd
+++ b/Scripts/Misc/PauseManager.gd
@@ -155,7 +155,10 @@ func do_lateral_input():
 			2: # Scale
 				if inputCue.x != 0 and inputCue != lastInput:
 					Global.zoomSize = clamp(Global.zoomSize+inputDir,zoomClamp[0],zoomClamp[1])
-					get_window().set_size(get_viewport().get_visible_rect().size*Global.zoomSize)
+					var window = get_window()
+					var newSize = Vector2i((get_viewport().get_visible_rect().size*Global.zoomSize).round())
+					window.set_position(window.get_position()+(window.size-newSize)/2)
+					window.set_size(newSize)
 		$PauseMenu/VBoxContainer.get_child(option+1).get_child(0).text = update_text(option+1)
 	lastInput = inputCue
 


### PR DESCRIPTION
When specifying window scale (2x, 3x etc.) in the options menu, then closing the window and running the game again, the window becomes oddly positioned:
![before](https://github.com/user-attachments/assets/1d1cb4a4-1c59-44e3-aef6-aab3f436e0cf)
This PR attempts to fix it by repositioning the window accordingly:
![_after](https://github.com/user-attachments/assets/1e8cfccd-c447-45c8-bf3d-3a7b4fb1dbca)
