### PR TITLE
Caverns 4 tests

### DIFF
--- a/Scripts/Gimmicks/Spring.gd
+++ b/Scripts/Gimmicks/Spring.gd
@@ -109,6 +109,7 @@ func physics_collision(body, hitVector):
 
 func _on_Diagonal_body_entered(body):
 	# diagonal springs are pretty straightforward
+	body.angle = body.gravityAngle
 	body.movement = hitDirection.rotated(rotation).rotated(-body.rotation)*speed[type]*60
 	$SpringAnimator.play(animList[animID])
 	if (hitDirection.y < 0):

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -417,11 +417,23 @@ func _process(delta):
 						# Array into the partner's input for the current frame
 						partner.inputs[i] = inputMemory[memoryPosition][i]
 				
+				#TODO: This current implimentation is better than what we had before,
+				#but it's still a little clunky. Will clean up this clode block later. - Ikey Ilex
+				
 				# x distance difference check, try to go to the partner
 				if (partner.inputs[INPUTS.XINPUT] == 0 and partner.inputs[INPUTS.YINPUT] == 0
 					or global_position.distance_to(partner.global_position) > 48 and round(movement.x/300) == 0
 					) and abs(global_position.x-partner.global_position.x) >= 32:
 					partner.inputs[INPUTS.XINPUT] = sign(global_position.x - partner.global_position.x)
+				
+				#If more than 64 pixels away on X, override AI control to come back.
+				if abs(global_position.x-partner.global_position.x) > 64:
+					partner.inputs[INPUTS.XINPUT] == sign(global_position.x-partner.global_position.x)
+				#Override AI control if Tails is ahead of Sonic
+				else:
+					var testPos = round(global_position.x + (0-direction))
+					if sign((partner.global_position.x - testPos)*direction) > 0:
+						partner.inputs[INPUTS.XINPUT] = sign(0-direction)
 				
 				# Jump if pushing a wall, slower then half speed, on a flat surface and is either normal or jumping
 				if (partner.currentState == STATES.NORMAL or partner.currentState == STATES.JUMP) and abs(partner.movement.x) < top/2.0 and snap_angle(partner.angle) == 0 or (partner.pushingWall != 0 and pushingWall == 0):
@@ -1085,6 +1097,13 @@ func kill(always = true):
 		if playerControl == 1 and Global.effectTheme.is_playing():
 			Global.music.play()
 			Global.effectTheme.stop()
+			
+		# If Player 1 dies and a partner exists, initiate respawn flying from current position.
+		if playerControl == 1 and partner:
+			var savedPos = partner.global_position
+			partner.respawn()
+			partner.global_position = savedPos
+			
 		collision_layer = 0
 		collision_mask = 0
 		z_index = 100

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -793,7 +793,7 @@ func _physics_process(delta):
 			switch_physics()
 			movement.x *= 0.5
 			movement.y *= 0.25
-			if currentState != STATES.RESPAWN:
+			if currentState != STATES.RESPAWN and movement.y != 0:
 				sfx[17].play()
 				var splash = Particle.instantiate()
 				splash.behaviour = splash.TYPE.FOLLOW_WATER_SURFACE

--- a/Scripts/Player/States/Respawn.gd
+++ b/Scripts/Player/States/Respawn.gd
@@ -42,8 +42,14 @@ func _physics_process(delta):
 		parent.collision_layer = layerMemory
 		
 		parent.movement.y = 0
-		# move to player y position
+		# move to Sonic's Y position...
 		parent.global_position.y = move_toward(parent.global_position.y,targetPoint.y,delta*60)
+		if (Global.waterLevel != null):
+			#Block Tails from going underwater in this state
+			parent.global_position.y = min(parent.global_position.y,Global.waterLevel-16)
+		else:
+			#Block Tails from going out of bounds, in case Sonic is dead.
+			parent.global_position.y = min(parent.global_position.y,parent.limitBottom-16)
 		
 		var distance = targetPoint.x-parent.global_position.x
 		# if far then fly by distance


### PR DESCRIPTION
Two small fixes:
1: When hitting a diagonal spring, the player's angle is reset, to prevent strange movement in certain conditions.
2: The water is not supposed to splash unless a player falls into it. If a player was standing still or moving on the ground, the splash would erroneously happen.