### PR TITLE
Properly mute Audio channels with volume set to "0"

### DIFF
--- a/Scripts/Global/Global.gd
+++ b/Scripts/Global/Global.gd
@@ -201,9 +201,19 @@ func load_settings():
 	
 	if file.has_section_key("Volume","SFX"):
 		AudioServer.set_bus_volume_db(AudioServer.get_bus_index("SFX"),file.get_value("Volume","SFX"))
+		# Set bus mute state
+		AudioServer.set_bus_mute(
+		AudioServer.get_bus_index("SFX"), # Auidio bus to mute
+		AudioServer.get_bus_volume_db(AudioServer.get_bus_index("SFX")) <= -40.0 # True if < -40.0
+		)
 	
 	if file.has_section_key("Volume","Music"):
 		AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Music"),file.get_value("Volume","Music"))
+		# Set bus mute state
+		AudioServer.set_bus_mute(
+		AudioServer.get_bus_index("Music"), # Auidio bus to mute
+		AudioServer.get_bus_volume_db(AudioServer.get_bus_index("Music")) <= -40.0 # True if < -40.0
+		)
 	
 	if file.has_section_key("Resolution","Zoom"):
 		zoomSize = file.get_value("Resolution","Zoom")


### PR DESCRIPTION
When setting volume to 0 in the options, quitting and restarting the game, audio will now be properly muted on reload.