### PR TITLE
AltSpawn: Get rid of hardcoded list of characters

### DIFF
--- a/Scene/Zones/BaseZone.tscn
+++ b/Scene/Zones/BaseZone.tscn
@@ -949,7 +949,7 @@ position = Vector2(3704, 72)
 [node name="AltSpawn" type="Node2D" parent="Entity"]
 position = Vector2(5649, 1498)
 script = ExtResource("38_8ssba")
-currentCharacter = 3
+current_character = 4
 
 [node name="ConveyorBelt" parent="Entity" instance=ExtResource("39_8a2xw")]
 position = Vector2(4864, 880)

--- a/Scripts/Misc/AltSpawn.gd
+++ b/Scripts/Misc/AltSpawn.gd
@@ -1,8 +1,8 @@
 extends Node2D
 
-@export_enum("Sonic","Tails","Knuckles","Amy")var currentCharacter = 0
+@export var current_character:Global.CHARACTERS = 1 as Global.CHARACTERS
 # alternative spawning location
 func _ready():
-	if currentCharacter == Global.PlayerChar1-1 and Global.currentCheckPoint == -1:
+	if current_character == Global.PlayerChar1 and Global.currentCheckPoint == -1:
 		Global.players[0].global_position = global_position
 		Global.players[0].camera.global_position = global_position

--- a/Scripts/Misc/AltSpawn.gd
+++ b/Scripts/Misc/AltSpawn.gd
@@ -1,8 +1,15 @@
+@tool
 extends Node2D
 
-@export var current_character:Global.CHARACTERS = 1 as Global.CHARACTERS
+@export var current_character:Global.CHARACTERS = 1 as Global.CHARACTERS:
+	set(value):
+		# Reject the value if the user chose "None" from the editor
+		if Engine.is_editor_hint() and value == Global.CHARACTERS.NONE:
+			return
+		current_character = value
+
 # alternative spawning location
 func _ready():
-	if current_character == Global.PlayerChar1 and Global.currentCheckPoint == -1:
+	if !Engine.is_editor_hint() and current_character == Global.PlayerChar1 and Global.currentCheckPoint == -1:
 		Global.players[0].global_position = global_position
 		Global.players[0].camera.global_position = global_position


### PR DESCRIPTION
Gets rid of a copy of character names list in AltSpawn.gd by using `@export` with a type annotation, instead of `@export_enum` with a hardcoded list of names.

Also, since after that change it became possible to select `Global.CHARACTERS.NONE` from the editor, I remedied it by making a custom setter that rejects "None" if it was assigned from the editor.