### PR TITLE
Fixes and improvements for BreakableWall object

### DIFF
--- a/Entities/Obstacles/BreakableWall.tscn
+++ b/Entities/Obstacles/BreakableWall.tscn
@@ -14,7 +14,16 @@ script = ExtResource("1")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("1")
 
+[node name="CollisionArea" type="Area2D" parent="."]
+collision_layer = 0
+collision_mask = 524288
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionArea"]
+shape = SubResource("1")
+
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("2")
 region_enabled = true
 region_rect = Rect2(0, 0, 16, 64)
+
+[connection signal="area_entered" from="CollisionArea" to="." method="_on_CollisionArea_area_entered"]

--- a/Scripts/Objects/BreakableWall.gd
+++ b/Scripts/Objects/BreakableWall.gd
@@ -59,9 +59,13 @@ func break_wall(player: PlayerChar, hitVector):
 func physics_collision(body: PlayerChar, hitVector):
 	# check hit is either left or right
 	if hitVector.x != 0:
-		# If the player is Knuckles or Amy doing the hammer attack, it's an auto-break.
+		# If the player is Knuckles or Amy doing the hammer attack, or Sonic
+		# (or potentially any other character who's able to use shields)
+		# using Fire Shield ability, it's an auto-break.
 		if body.character == Global.CHARACTERS.KNUCKLES or \
-		   body.character == Global.CHARACTERS.AMY and body.get_state() == PlayerChar.STATES.AMYHAMMER:
+		   body.character == Global.CHARACTERS.AMY and body.get_state() == PlayerChar.STATES.AMYHAMMER or \
+		   (body.get_shield() == PlayerChar.SHIELDS.FIRE and body.get_state() == PlayerChar.STATES.JUMP and
+		   body.shieldSprite.animation == "FireAction"):
 			break_wall(body, hitVector)
 			return
 		

--- a/Scripts/Objects/BreakableWall.gd
+++ b/Scripts/Objects/BreakableWall.gd
@@ -58,11 +58,10 @@ func physics_collision(body: PlayerChar, hitVector):
 	# check hit is either left or right
 	if hitVector.x != 0:
 		# If the player is Knuckles or Amy doing the hammer attack, it's an auto-break.
-		match body.character:
-			Global.CHARACTERS.KNUCKLES, \
-			Global.CHARACTERS.AMY when body.get_state() == PlayerChar.STATES.AMYHAMMER:
-				break_wall(body, hitVector)
-				return
+		if body.character == Global.CHARACTERS.KNUCKLES or \
+		   body.character == Global.CHARACTERS.AMY and body.get_state() == PlayerChar.STATES.AMYHAMMER:
+			break_wall(body, hitVector)
+			return
 		
 		# Non-Knuckles characters can't break
 		if get_collision_layer_value(19):

--- a/Scripts/Objects/BreakableWall.gd
+++ b/Scripts/Objects/BreakableWall.gd
@@ -21,9 +21,11 @@ func break_wall(player: PlayerChar, hitVector):
 	# disable physics altering masks
 	set_collision_layer_value(16,false)
 	set_collision_mask_value(14,false)
+	$CollisionArea.set_collision_mask_value(20,false)
 	# give frame buffer
 	await get_tree().process_frame
 	$CollisionShape2D.disabled = true
+	$CollisionArea/CollisionShape2D.disabled = true
 	$Sprite2D.visible = false
 	Global.play_sound(sound)
 	
@@ -81,3 +83,12 @@ func physics_collision(body: PlayerChar, hitVector):
 			body.movement.x = 0
 				
 	return
+
+func _on_CollisionArea_area_entered(area: Area2D) -> void:
+	if area.name == "InstaShieldHitbox":
+		var player: PlayerChar = area.get_parent().get_parent()
+		if player.character == Global.CHARACTERS.AMY:
+			# It should be okay to have either (1,0) or (-1,0) as a hit vector,
+			# as the Y part of the vector is not used by break_wall() anyway
+			var hit_vector: Vector2 = Vector2(sign(global_position.x - player.global_position.x), 0.0)
+			break_wall(player, hit_vector)


### PR DESCRIPTION
This PR does the following:
* Allows Amy to break walls with her hammer spin.
* Allows Sonic to break walls by using Fire Shield ability (technically, it may be any other character who's able to use shield abilities, there's no check for it being Sonic).
* Fixes a bug with Knuckles not being able to break walls by running into them (introduced in 7945231d9804e9be1528f4ea683d5f291f103581; my bad!)