### PR TITLE
Misc. small fixes

### DIFF
--- a/Audio/Soundtrack/1. SWD_Invincible.ogg.import
+++ b/Audio/Soundtrack/1. SWD_Invincible.ogg.import
@@ -13,7 +13,7 @@ dest_files=["res://.godot/imported/1. SWD_Invincible.ogg-c76450a96eddb43d7770920
 [params]
 
 loop=true
-loop_offset=0
+loop_offset=1.472
 bpm=0
 beat_count=0
 bar_beats=4

--- a/Audio/Soundtrack/2. SWD_SpeedUp.ogg.import
+++ b/Audio/Soundtrack/2. SWD_SpeedUp.ogg.import
@@ -13,7 +13,7 @@ dest_files=["res://.godot/imported/2. SWD_SpeedUp.ogg-524817b2b870bf74b8f2d5f20f
 [params]
 
 loop=true
-loop_offset=0
+loop_offset=1.412
 bpm=0
 beat_count=0
 bar_beats=4

--- a/Scene/Presentation/CharacterSelect.tscn
+++ b/Scene/Presentation/CharacterSelect.tscn
@@ -287,7 +287,6 @@ region_enabled = true
 region_rect = Rect2(676, 205, 33, 35)
 
 [node name="TailsTails" type="Sprite2D" parent="UI/Labels/CharacterOrigin/Tails"]
-visible = false
 z_index = -1
 position = Vector2(-9, 7)
 texture = ExtResource("4")

--- a/Scripts/Boss/BossBase.gd
+++ b/Scripts/Boss/BossBase.gd
@@ -1,6 +1,6 @@
 class_name BossBase extends CharacterBody2D
 
-@export_enum("Normal", "Fire", "Elec", "Water") var damageType = 0
+@export var damage_type: Global.HAZARDS = Global.HAZARDS.NORMAL
 var playerHit = []
 
 @export var hp = 8
@@ -54,7 +54,7 @@ func _physics_process(delta):
 						defeated.emit()
 				# if destroying the enemy fails and hit player exists then hit player
 				elif (i.has_method("hit_player")):
-					if i.hit_player(global_position,damageType):
+					if i.hit_player(global_position,damage_type):
 						hit_player.emit()
 
 func _on_body_entered(body):

--- a/Scripts/Boss/BossBase.gd
+++ b/Scripts/Boss/BossBase.gd
@@ -65,8 +65,7 @@ func _on_body_entered(body):
 
 func _on_body_exited(body):
 	# remove from player list
-	if (playerHit.has(body)):
-		playerHit.erase(body)
+	playerHit.erase(body)
 
 
 func _on_DamageArea_area_entered(area):
@@ -80,5 +79,4 @@ func _on_DamageArea_area_entered(area):
 func _on_HitBox_area_exited(area):
 	# remove from damage area
 	if area.get("parent") != null:
-		if playerHit.has(area.parent):
-			playerHit.erase(area.parent)
+		playerHit.erase(area.parent)

--- a/Scripts/Boss/RobotnikTemplate.gd
+++ b/Scripts/Boss/RobotnikTemplate.gd
@@ -123,9 +123,9 @@ func _physics_process(delta):
 # animation to play, time is how long the animation should play for until it stops
 func set_animation(animation = "default", time = 0.0):
 	# check that the animation exists in the animationPriority list
-	if animationPriority.has(animation):
+	var animID: int = animationPriority.find(animation)
+	if animID != -1:
 		# if the animation exists then compare the position
-		var animID = animationPriority.find(animation)
 		var currentAnimID = animationPriority.find($EggMobile/Robotnik.animation)
 		
 		# if the new animation ID is higher then the current one or the animation time isn't running then play the animation

--- a/Scripts/Enemies/EnemyBase.gd
+++ b/Scripts/Enemies/EnemyBase.gd
@@ -1,6 +1,6 @@
 class_name EnemyBase extends CharacterBody2D
 
-@export_enum("Normal", "Fire", "Elec", "Water") var damageType = 0
+@export var damage_type: Global.HAZARDS = Global.HAZARDS.NORMAL
 var playerHit = []
 
 var Explosion = preload("res://Entities/Misc/BadnickSmoke.tscn")
@@ -38,7 +38,7 @@ func _process(delta):
 				return false
 			# if destroying the enemy fails and hit player exists then hit player
 			if (i.has_method("hit_player")):
-				i.hit_player(global_position,damageType)
+				i.hit_player(global_position,damage_type)
 	# move
 	if defaultMovement:
 		translate(velocity*delta)

--- a/Scripts/Enemies/EnemyBase.gd
+++ b/Scripts/Enemies/EnemyBase.gd
@@ -51,8 +51,7 @@ func _on_body_entered(body):
 
 func _on_body_exited(body):
 	# remove from player list
-	if (playerHit.has(body)):
-		playerHit.erase(body)
+	playerHit.erase(body)
 
 func _on_DamageArea_area_entered(area):
 	# damage checking

--- a/Scripts/Enemies/EnemyProjectileBase.gd
+++ b/Scripts/Enemies/EnemyProjectileBase.gd
@@ -56,8 +56,7 @@ func _on_body_entered(body):
 
 ## This usually indicates that a player has exited the damage collision for the bullet
 func _on_body_exited(body):
-	if entities_hit.has(body):
-		entities_hit.erase(body)
+	entities_hit.erase(body)
 
 
 func _on_DamageArea_area_entered(area):

--- a/Scripts/Gimmicks/Bridge.gd
+++ b/Scripts/Gimmicks/Bridge.gd
@@ -99,8 +99,7 @@ func _on_PlayerCheck_body_entered(body):
 	player.append(body)
 
 func _on_PlayerCheck_body_exited(body):
-	if (player.has(body)):
-		player.erase(body)
+	player.erase(body)
 
 # draw logs
 func _draw():

--- a/Scripts/Gimmicks/CorkscrewLoop.gd
+++ b/Scripts/Gimmicks/CorkscrewLoop.gd
@@ -99,8 +99,7 @@ func _on_EnteranceL_body_entered(body):
 
 
 func _on_EnteranceL_body_exited(body):
-	if (playerListL.has(body)):
-		playerListL.erase(body)
+	playerListL.erase(body)
 
 func _on_EnteranceR_body_entered(body):
 	if !playerListR.has(body):
@@ -108,8 +107,7 @@ func _on_EnteranceR_body_entered(body):
 
 
 func _on_EnteranceR_body_exited(body):
-	if (playerListR.has(body)):
-		playerListR.erase(body)
+	playerListR.erase(body)
 
 # draw self several times based on length
 func _draw():

--- a/Scripts/Gimmicks/HorizontalBar.gd
+++ b/Scripts/Gimmicks/HorizontalBar.gd
@@ -358,11 +358,11 @@ func _on_bar_area_body_exited(body):
 	remove_player(body)
 	
 func remove_player(player):
-	if players.has(player):
+	var index: int = players.find(player)
+	if index != -1:
 		# Clean out the player from all player-linked arrays.
-		var getIndex = players.find(player)
 		players.erase(player)
-		playersMode.remove_at(getIndex)
-		playersEntryVel.remove_at(getIndex)
+		playersMode.remove_at(index)
+		playersEntryVel.remove_at(index)
 		if player.get_state() == player.STATES.GIMMICK:
 			player.set_state(player.STATES.NORMAL)

--- a/Scripts/Gimmicks/ScrewPlatform.gd
+++ b/Scripts/Gimmicks/ScrewPlatform.gd
@@ -71,8 +71,7 @@ func _on_playerChecker_body_entered(body):
 
 
 func _on_playerChecker_body_exited(body):
-	if players.has(body):
-		players.erase(body)
+	players.erase(body)
 
 
 # prevent unnecessary run time processing for object

--- a/Scripts/Level/Level.gd
+++ b/Scripts/Level/Level.gd
@@ -3,8 +3,8 @@ class_name Level extends Node2D
 @export var music = preload("res://Audio/Soundtrack/6. SWD_TLZa1.ogg")
 @export var nextZone = load("res://Scene/Zones/BaseZone.tscn")
 
-@export_enum("Bird", "Squirrel", "Rabbit", "Chicken", "Penguin", "Seal", "Pig", "Eagle", "Mouse", "Monkey", "Turtle", "Bear")var animal1 = 0
-@export_enum("Bird", "Squirrel", "Rabbit", "Chicken", "Penguin", "Seal", "Pig", "Eagle", "Mouse", "Monkey", "Turtle", "Bear")var animal2 = 1
+@export var animal1: Animal.ANIMAL_TYPE = Animal.ANIMAL_TYPE.BIRD
+@export var animal2: Animal.ANIMAL_TYPE = Animal.ANIMAL_TYPE.SQUIRREL
 
 # Boundries
 @export var setDefaultLeft = true

--- a/Scripts/Misc/Animal.gd
+++ b/Scripts/Misc/Animal.gd
@@ -1,4 +1,4 @@
-extends Node2D
+class_name Animal extends Node2D
 
 enum ANIM_TYPE {FLAP,CHANGE_ON_FALL}
 var anim_type: ANIM_TYPE = ANIM_TYPE.FLAP

--- a/Scripts/Misc/NumeralDisplay.gd
+++ b/Scripts/Misc/NumeralDisplay.gd
@@ -30,8 +30,8 @@ func _draw():
 	# calculate the resolution of the sprite text
 	var getRes = Vector2(texture.get_width()/float(hframes),texture.get_height()/float(vframes))
 	for i in string.length():
-		if (stringLookup.has(string[i])):
-			var charID = stringLookup[string[i]]
+		var charID: int = stringLookup[string[i]]
+		if charID != -1:
 			draw_texture_rect_region(texture,
-			Rect2(Vector2(getRes.x*i,0),getRes),
-			Rect2(Vector2(fmod(charID,hframes)*getRes.x,floor(charID/hframes)*getRes.y),getRes))
+				Rect2(Vector2(getRes.x*i,0),getRes),
+				Rect2(Vector2(fmod(charID,hframes)*getRes.x,floor(charID/hframes)*getRes.y),getRes))

--- a/Scripts/Objects/CollapseLayer.gd
+++ b/Scripts/Objects/CollapseLayer.gd
@@ -106,5 +106,4 @@ func _on_body_entered(body):
 		players.append(body)
 
 func _on_body_exited(body):
-	if players.has(body):
-		players.erase(body)
+	players.erase(body)

--- a/Scripts/Objects/CollapsePlatform.gd
+++ b/Scripts/Objects/CollapsePlatform.gd
@@ -98,5 +98,4 @@ func _on_body_entered(body):
 		players.append(body)
 
 func _on_body_exited(body):
-	if players.has(body):
-		players.erase(body)
+	players.erase(body)

--- a/Scripts/Objects/ForceAngleSides.gd
+++ b/Scripts/Objects/ForceAngleSides.gd
@@ -67,9 +67,9 @@ func _on_ForceAngleSides_body_entered(body):
 
 
 func _on_ForceAngleSides_body_exited(body):
-	if players.has(body):
+	var index: int = players.find(body)
+	if index != -1:
 		# remove angle rotation index
-		var getIndex = players.find(body)
-		contactPoint.remove_at(getIndex)
+		contactPoint.remove_at(index)
 		
 		players.erase(body)

--- a/Scripts/Objects/ForceRoll.gd
+++ b/Scripts/Objects/ForceRoll.gd
@@ -28,5 +28,4 @@ func _on_ForceRoll_body_entered(body):
 
 func _on_ForceRoll_body_exited(body):
 	body.forceRoll -= 1
-	#if players.has(body):
-		#players.erase(body)
+	#players.erase(body)

--- a/Scripts/Objects/Hazard.gd
+++ b/Scripts/Objects/Hazard.gd
@@ -25,5 +25,4 @@ func _on_body_entered(body):
 
 
 func _on_body_exited(body):
-	if (entities_hit.has(body)):
-		entities_hit.erase(body)
+	entities_hit.erase(body)

--- a/Scripts/Objects/LayerSwitcher.gd
+++ b/Scripts/Objects/LayerSwitcher.gd
@@ -71,5 +71,4 @@ func _on_layer_switcher_body_entered(body):
 
 func _on_layer_switcher_body_exited(body):
 	if not Engine.is_editor_hint():
-		if playerList.has(body):
-			playerList.erase(body)
+		playerList.erase(body)

--- a/Scripts/Objects/SpecialStageRing.gd
+++ b/Scripts/Objects/SpecialStageRing.gd
@@ -73,8 +73,9 @@ func _process(delta: float) -> void:
 					if is_instance_valid(player.superAnimator):
 						player.superAnimator.play("PowerDown")
 				# reset super sonic texture
-				if player.character == Global.CHARACTERS.SONIC:
-					player.sprite.texture = player.normalSprite
+				var player_avatar: PlayerAvatar = player.get_avatar()
+				if player_avatar.super_sprite != null:
+					player.sprite.texture = player_avatar.normal_sprite
 				# reset physics
 				player.switch_physics()
 				player.visible = true


### PR DESCRIPTION
This PR does the following:
* Sets a loop point for Invincibility and Speed Up themes in order to skip the intro part when looping back.
* Fixes a runtime error when entering a special stage ring as Sonic.
* Removes hardcoded lists of animals in `Level.gd` and makes the code reuse the enum from `Animal.gd`.
* Removes redundant checks before removing array elements (`Array.erase()` doesn't raise an error if the array doesn't contain the removed value).
* Removes redundant calls to `Array.has()` and reuses the returned value from `Array.find()`.
* Removes hardcoded lists of names of hazard types in `BossBase.gd` and `EnemyBase.gd` and reuses the `Global.HAZARDS` enum instead.
* Fixes Tails' tails not being visible in the Character Select menu when choosing Tails only.