### PR TITLE
Implement MusicController

### DIFF
--- a/Entities/Misc/HUD.tscn
+++ b/Entities/Misc/HUD.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=32 format=3 uid="uid://c30uceea18q1w"]
+[gd_scene load_steps=31 format=3 uid="uid://c30uceea18q1w"]
 
 [ext_resource type="Material" uid="uid://bveqi5m5ihsgj" path="res://Shaders/PlayerPalette.tres" id="2_xy7bp"]
 [ext_resource type="FontFile" uid="uid://cj70hn8i05uo5" path="res://Graphics/HUD/hud_lives_numerals.png" id="3_eauoj"]
@@ -16,7 +16,6 @@
 [ext_resource type="PackedScene" uid="uid://bass3w6af55vw" path="res://Tools/Timing/ProcessTimer.tscn" id="13_g84gd"]
 [ext_resource type="Texture2D" uid="uid://60ak1q0xrn1s" path="res://Graphics/HUD/hud_gametimeover.png" id="15_oja0m"]
 [ext_resource type="AudioStream" uid="uid://dh4rsaka62ph4" path="res://Audio/SFX/Gimmicks/Switch.wav" id="16"]
-[ext_resource type="AudioStream" uid="uid://dnyw7remih6op" path="res://Audio/Soundtrack/8. SWD_GameOver.ogg" id="16_vq3lx"]
 [ext_resource type="AudioStream" uid="uid://clgobastngtvy" path="res://Audio/SFX/Misc/Score.wav" id="17"]
 
 [sub_resource type="Animation" id="5"]
@@ -1000,10 +999,6 @@ frame = 2
 libraries = {
 "": SubResource("AnimationLibrary_dmnhc")
 }
-
-[node name="GameOverMusic" type="AudioStreamPlayer" parent="GameOver"]
-stream = ExtResource("16_vq3lx")
-bus = &"Music"
 
 [node name="Water" type="CanvasLayer" parent="."]
 

--- a/Scene/Main.tscn
+++ b/Scene/Main.tscn
@@ -1,13 +1,9 @@
-[gd_scene load_steps=16 format=3 uid="uid://byje3iiukvt4p"]
+[gd_scene load_steps=12 format=3 uid="uid://byje3iiukvt4p"]
 
-[ext_resource type="AudioStream" uid="uid://dec4ik84l88go" path="res://Audio/Soundtrack/2. SWD_SpeedUp.ogg" id="1"]
 [ext_resource type="Script" path="res://Scripts/Global/Main.gd" id="2"]
-[ext_resource type="AudioStream" uid="uid://b30ai1lqlh32u" path="res://Audio/Soundtrack/3. SWD_1Up.ogg" id="3"]
 [ext_resource type="PackedScene" uid="uid://c58ontqoxjuti" path="res://Scene/Presentation/PoweredByWorlds.tscn" id="4"]
-[ext_resource type="AudioStream" uid="uid://o4f15hnb5thp" path="res://Audio/Soundtrack/7. SWD_Drowning.ogg" id="5"]
 [ext_resource type="PackedScene" uid="uid://b2xskcomtpo2x" path="res://Entities/Misc/ControllerMenu.tscn" id="6"]
 [ext_resource type="PackedScene" uid="uid://c1xhc4uh26inb" path="res://Entities/Misc/PauseMenu.tscn" id="7"]
-[ext_resource type="AudioStream" uid="uid://25oy5g80wsxu" path="res://Audio/Soundtrack/5. SWD_Boss.ogg" id="8"]
 
 [sub_resource type="CanvasItemMaterial" id="1"]
 
@@ -141,29 +137,6 @@ process_mode = 1
 
 [node name="PoweredByWorlds" parent="SceneLoader" instance=ExtResource("4")]
 
-[node name="Music" type="Node" parent="."]
-process_mode = 1
-
-[node name="Music" type="AudioStreamPlayer" parent="Music"]
-autoplay = true
-bus = &"Music"
-
-[node name="BossTheme" type="AudioStreamPlayer" parent="Music"]
-stream = ExtResource("8")
-bus = &"Music"
-
-[node name="EffectTheme" type="AudioStreamPlayer" parent="Music"]
-stream = ExtResource("1")
-bus = &"Music"
-
-[node name="Drowning" type="AudioStreamPlayer" parent="Music"]
-stream = ExtResource("5")
-bus = &"Music"
-
-[node name="Life" type="AudioStreamPlayer" parent="Music"]
-stream = ExtResource("3")
-bus = &"Music"
-
 [node name="GUI" type="CanvasLayer" parent="."]
 process_mode = 3
 layer = 128
@@ -186,5 +159,3 @@ autoplay = "RESET"
 [node name="ControllerMenu" parent="GUI" instance=ExtResource("6")]
 
 [node name="Pause" parent="GUI" instance=ExtResource("7")]
-
-[connection signal="finished" from="Music/Life" to="." method="_on_Life_finished"]

--- a/Scripts/Boss/BossBoundrySetter.gd
+++ b/Scripts/Boss/BossBoundrySetter.gd
@@ -46,19 +46,15 @@ func _on_BoundrySetter_body_entered(body):
 						if lockBottom:
 							i.limitBottom = min(global_position.y+screenSize.y/2,Global.hardBorderBottom)
 					
-					Global.main.set_volume(-50)
-					await Global.main.volume_set
-					Global.main.set_volume(0,100)
 					
-					Global.bossMusic.play()
+					MusicController.play_music_theme(MusicController.MusicTheme.BOSS_THEME)
 					boss.active = true
 					
 					if boss.has_signal("boss_over"):
 						boss.connect("boss_over",Callable(self,"boss_completed"))
 
 func boss_completed():
-	Global.bossMusic.stop()
-	Global.music.play()
+	MusicController.stop_music_theme(MusicController.MusicTheme.BOSS_THEME)
 	# set boundries for players
 	for i in Global.players:
 		if is_instance_valid(i):

--- a/Scripts/Global/Global.gd
+++ b/Scripts/Global/Global.gd
@@ -46,17 +46,6 @@ func is_in_any_stage_clear_phase() -> bool:
 func reset_stage_clear_phase() -> void:
 	set_stage_clear_phase(Global.STAGE_CLEAR_PHASES.NOT_STARTED)
 
-# Music
-var musicParent = null
-var music = null
-var bossMusic = null
-var effectTheme = null
-var drowning = null
-var life = null
-# song themes to play for things like invincibility and speed shoes
-var themes = [preload("res://Audio/Soundtrack/1. SWD_Invincible.ogg"),preload("res://Audio/Soundtrack/2. SWD_SpeedUp.ogg"),preload("res://Audio/Soundtrack/4. SWD_StageClear.ogg")]
-# index for current theme
-var currentTheme = 0
 
 # Sound, used for play_sound (used for a global sound, use this if multiple nodes use the same sound)
 var soundChannel = AudioStreamPlayer.new()
@@ -229,21 +218,15 @@ func play_sound(sound = null) -> void:
 ## use a check function to see if a score increase would go above 50,000
 func check_score_life(score_add: int = 0) -> void:
 	if score / 50000 < (score + score_add) / 50000:
-		life.play()
+		MusicController.play_music_theme(MusicController.MusicTheme._1UP)
 		lives += 1
-		effectTheme.volume_db = -100
-		music.volume_db = -100
-		bossMusic.volume_db = -100
 
 
 ## use this to set the stage clear theme, only runs if stage clear phase is NONE
 func stage_clear() -> void:
 	if !is_in_any_stage_clear_phase():
-		currentTheme = 2
-		music.stream = themes[currentTheme]
-		music.play()
-		effectTheme.stop()
-		bossMusic.stop()
+		MusicController.stop_music_theme(MusicController.MusicTheme.LEVEL_THEME)
+		MusicController.play_music_theme(MusicController.MusicTheme.STAGE_CLEAR)
 
 
 ## Emit the stage started signal

--- a/Scripts/Global/MusicController.gd
+++ b/Scripts/Global/MusicController.gd
@@ -1,0 +1,367 @@
+extends Node
+
+
+# amount of decibels to fade the music in/out for
+const _FADE_AMOUNT: float = 80.0
+
+# amount of time (in milliseconds) to fade all the other music out (or back in)
+# after playing a music theme
+const _FADE_SPEED: int = 1*1000
+
+## Level music has the lowest priority, and the Game Over theme has the highest.
+enum PriorityLevel {
+	LEVEL_THEME,
+	EFFECT_THEME,
+	BOSS_THEME,
+	DROWNING_THEME,
+	_1UP_JINGLE,
+	STAGE_CLEAR_THEME,
+	GAME_OVER_THEME
+}
+
+enum _PlayStatus {
+	STOPPED,
+	PRE_PLAY, # preparing for being played (fading out other music themes that have lower priority)
+	PLAYING,
+	POST_PLAY # fading out, as well as fading other music themes that have lower priority back in
+}
+
+class _MusicThemePlayer extends AudioStreamPlayer:
+	var volume_db_proxy: float: # we'll use this to accumulate the effect from multiple simultaneous fades
+		set(value):				# (apparently, the actual `volume_db` can't be set lower than `-80.0`)
+			volume_db_proxy = value
+			volume_db = value
+	var play_status: _PlayStatus
+	var priority: PriorityLevel
+	var fade_out_other_themes: bool # if true, themes with lower priority are faded out gradually,
+									# otherwise they're muted immediately
+	var fade_in_other_themes: bool # if true, themes with lower priority are faded in gradually,
+								   # otherwise they're unmuted immediately
+	var fade_when_stopped: bool # if true, theme fades out when stopped via `stop_music_theme()`
+	var restart_level_theme: bool # if true, level theme plays from the start
+								  # after this music theme stops playing
+	var allow_replay: bool
+	
+	func _init(
+		p_stream: AudioStream,
+		p_priority: PriorityLevel = PriorityLevel.LEVEL_THEME,
+		p_fade_out_other_themes: bool = false,
+		p_fade_in_other_themes: bool = false,
+		p_fade_when_stopped: bool = false,
+		p_restart_level_theme: bool = false,
+		p_allow_replay: bool = false
+	) -> void:
+		bus = &"Music"
+		self.volume_db_proxy = 0.0 # the use of `self` is intended, no need to invoke the setter here
+		play_status = _PlayStatus.STOPPED
+		stream = p_stream
+		priority = p_priority
+		fade_out_other_themes = p_fade_out_other_themes
+		fade_in_other_themes = p_fade_in_other_themes
+		fade_when_stopped = p_fade_when_stopped
+		restart_level_theme = p_restart_level_theme
+		allow_replay = p_allow_replay
+
+enum MusicTheme {
+	LEVEL_THEME,
+	INVINCIBLE,
+	SPEED_UP,
+	BOSS_THEME,
+	STAGE_CLEAR,
+	DROWNING,
+	_1UP,
+	GAME_OVER
+}
+# TODO: Make this a typed dictionary (Dictionary[MusicTheme, _MusicThemePlayer])
+# when transitioning to Godot 4.4
+var _music_theme_players: Dictionary = {
+	# ID                                                path                                             priority                         fade out others   fade in others   fade when stopped   restart level theme   replay
+	MusicTheme.LEVEL_THEME: _create_music_theme(null, PriorityLevel.LEVEL_THEME),
+	MusicTheme.INVINCIBLE:  _create_music_theme(preload("res://Audio/Soundtrack/1. SWD_Invincible.ogg"), PriorityLevel.EFFECT_THEME,     false,            false,           false,              true,                 false),
+	MusicTheme.SPEED_UP:    _create_music_theme(preload("res://Audio/Soundtrack/2. SWD_SpeedUp.ogg"),    PriorityLevel.EFFECT_THEME,     false,            false,           false,              true,                 false),
+	MusicTheme.BOSS_THEME:  _create_music_theme(preload("res://Audio/Soundtrack/5. SWD_Boss.ogg"),       PriorityLevel.BOSS_THEME,       true,             false,           true,               true,                 false),
+	MusicTheme.STAGE_CLEAR: _create_music_theme(preload("res://Audio/Soundtrack/4. SWD_StageClear.ogg"), PriorityLevel.STAGE_CLEAR_THEME),
+	MusicTheme.DROWNING:    _create_music_theme(preload("res://Audio/Soundtrack/7. SWD_Drowning.ogg"),   PriorityLevel.DROWNING_THEME,   false,            false,           false,              true,                 false),
+	MusicTheme._1UP:        _create_music_theme(preload("res://Audio/Soundtrack/3. SWD_1Up.ogg"),        PriorityLevel._1UP_JINGLE,      false,            true,            false,              false,                true),
+	MusicTheme.GAME_OVER:   _create_music_theme(preload("res://Audio/Soundtrack/8. SWD_GameOver.ogg"),   PriorityLevel.GAME_OVER_THEME)
+}
+
+# contains the last played music theme of each priority
+var _last_played_music_by_priority: Array[_MusicThemePlayer] = []
+
+# signalizes all music playing coroutines to stop
+var _reset_music_themes_flag: bool = false
+
+
+func _fade_music_themes(themes: Array[_MusicThemePlayer], _sign: int) -> void:
+	var tree: SceneTree = get_tree()
+	var physics_frame: Signal = tree.physics_frame
+	var volume_step: float
+	var total_volume_change: float = 0.0
+	var delta: int
+	var prev_time: int
+	var cur_time: int = Time.get_ticks_msec()
+	var keep_fading: bool = true
+	while keep_fading:
+		await physics_frame
+		prev_time = cur_time
+		cur_time = Time.get_ticks_msec()
+		# abort if `reset_music_themes()` was called while we're fading out/in
+		if _reset_music_themes_flag:
+			return
+		# skip fading while the game is paused
+		if tree.paused:
+			continue
+		# calculate time passed since the previous frame and total time
+		delta = cur_time - prev_time
+		# calculate the amount of volume to change at the current step
+		volume_step = _FADE_AMOUNT * delta / _FADE_SPEED
+		# due to the way how `physics_process` works, the fading process
+		# may take slightly more time than specified in `_FADE_SPEED`,
+		# which is why we need to compensate for the "overflow"
+		# that might happen on the last iteration by clamping
+		# the amount of volume changed at the current step
+		total_volume_change += volume_step
+		if total_volume_change >= _FADE_AMOUNT:
+			keep_fading = false # this will be the last iteration
+			volume_step -= total_volume_change - _FADE_AMOUNT # compensate for the "overflow"
+		volume_step *= _sign
+		# change the voulme for all themes with lower priority
+		for theme: _MusicThemePlayer in themes:
+			theme.volume_db_proxy += volume_step
+	
+
+## Plays the specified music theme while muting out (either instantly,
+## or by gradually fading out) all the other themes that have lower priority,
+## then fading them back in after the specified theme ended playing.[br]
+## * [param theme_id] - music theme to play.[br]
+## * [param time] - time (in milliseconds) to play the [param theme], if the latter is looped.[br]
+## NOTES:[br]
+## * If [code]theme_id == MusicTheme.LEVEL[/code] and level theme wasn't previously
+##   set (which can be done either via the `level_music_theme` property in
+##   the editor, or via [member set_level_music]), this function does nothing.
+func play_music_theme(theme_id: MusicTheme) -> void:
+	var theme: _MusicThemePlayer = _music_theme_players[theme_id]
+
+	# if it's a level theme and wasn't previously set via `set_level_music()`,
+	# or if the theme is already playing and re-playing is not allowed,
+	# then we have a quick exit
+	if (theme_id == MusicTheme.LEVEL_THEME and theme.stream == null or
+		theme.playing and not theme.allow_replay):
+		return
+	
+	var priority: PriorityLevel = theme.priority
+	var prev_theme: _MusicThemePlayer = _last_played_music_by_priority[priority]
+	_last_played_music_by_priority[priority] = theme # replace the last played music of this priority
+	if prev_theme != null and prev_theme.play_status == _PlayStatus.PRE_PLAY:
+		# we are already preparing another music theme with the same priority
+		# for being played (fading out all music with lower priority), so all
+		# we need to do is to replace the last played music of the same priority
+		# (which we just did; see the above comment) and reset the play status
+		# of the previous music theme if we aren't re-playing the same theme -
+		# and then we can have a quick exit
+		if prev_theme != theme:
+			prev_theme.play_status = _PlayStatus.STOPPED
+		return
+	
+	# pick other music themes with lower priority, so we can fade them out
+	var other_themes: Array[_MusicThemePlayer] = []
+	for other_theme_id: int in MusicTheme.size():
+		var other_theme: _MusicThemePlayer = _music_theme_players[other_theme_id]
+		if other_theme.priority < priority:
+			other_themes.append(other_theme)
+	
+	if prev_theme != null and prev_theme.play_status == _PlayStatus.PLAYING:
+		# this can be one of the following sitiations:
+		# a) music theme with the same priority is already being played and we're replacing it,
+		# b) we're re-playing the same music theme
+		# in either of those cases we don't need to fade out other music
+		pass
+	elif not theme.fade_out_other_themes:
+		# if there's no fadeout, then we can simply mute
+		# all the other music that has lower priority
+		for other_theme: _MusicThemePlayer in other_themes:
+			other_theme.volume_db_proxy -= _FADE_AMOUNT
+	else:
+		# otherwise we need to gradually fade out
+		# all the other music themes with lower priority
+		theme.play_status = _PlayStatus.PRE_PLAY
+		await _fade_music_themes(other_themes, -1)
+		# abort if `reset_music_themes()` was called
+		if _reset_music_themes_flag:
+			return
+	
+	# the theme might have been replaced by another call of `play_music_theme()`
+	# while we were fading out all the other music
+	theme = _last_played_music_by_priority[priority]
+	
+	# only play the music if it wasn't stopped via `stop_music_theme()`
+	# while we were fading out all the other music (if the music was stopped,
+	# then we can skip playing it and proceed to fading all the other music back in)
+	if theme.play_status != _PlayStatus.POST_PLAY:
+		# stop the previous theme and play the current one
+		if prev_theme != null and (prev_theme.play_status == _PlayStatus.PLAYING or prev_theme.play_status == _PlayStatus.PRE_PLAY):
+			prev_theme.stop()
+			prev_theme.play_status = _PlayStatus.STOPPED
+		theme.play()
+		theme.play_status = _PlayStatus.PLAYING
+		
+		# wait for the theme to finish playing
+		var tree: SceneTree = get_tree()
+		var physics_frame: Signal = tree.physics_frame
+		while (theme.playing or tree.paused) and theme.play_status == _PlayStatus.PLAYING:
+			await physics_frame
+			# abort if `reset_music_themes()` was called
+			if _reset_music_themes_flag:
+				return
+	
+		# if the theme was stopped via `stop_music_theme()` (`POST_PLAY` status),
+		# we need to fade out the theme
+		if theme.fade_when_stopped and theme.play_status == _PlayStatus.POST_PLAY:
+			await _fade_music_themes([theme], -1)
+			# abort if `reset_music_themes()` was called
+			if _reset_music_themes_flag:
+				return
+			# stop the theme and restore its volume
+			theme.stop()
+			theme.volume_db_proxy += _FADE_AMOUNT
+
+	# remove the current theme from the list of last played themes
+	_last_played_music_by_priority[priority] = null
+	
+	# fade all the other music back in
+	if not theme.fade_in_other_themes:
+		for other_theme: _MusicThemePlayer in other_themes:
+			other_theme.volume_db_proxy += _FADE_AMOUNT
+	else:
+		theme.play_status = _PlayStatus.POST_PLAY
+		await _fade_music_themes(other_themes, 1)
+		# abort if `reset_music_themes()` was called
+		if _reset_music_themes_flag:
+			return
+	
+	# restart the level theme, if needed
+	if theme.restart_level_theme:
+		seek_music_theme(MusicTheme.LEVEL_THEME, 0.0)
+	
+	# finally, set the `STOPPED` status, and we're done
+	theme.play_status = _PlayStatus.STOPPED
+
+## Stops the specified music theme.[br]
+## [param theme_id] - music theme to stop.[br]
+## NOTES:[br]
+## * If [code]theme_id == MusicTheme.LEVEL[/code] and level theme wasn't previously
+## set via [member set_level_music] or set to [code]null[/code], this function does nothing.
+func stop_music_theme(theme_id: MusicTheme) -> void:
+	var theme: _MusicThemePlayer = _music_theme_players[theme_id]
+	if theme_id == MusicTheme.LEVEL_THEME and theme.stream == null:
+		return
+	
+	# if the theme was in `PRE_PLAY` or `PLAYING` stage, change it to `POST_PLAY`,
+	# so that the corresponding `play_music_theme()` coroutine would know
+	# that it can skip playing the theme
+	if theme.play_status != _PlayStatus.STOPPED:
+		theme.play_status = _PlayStatus.POST_PLAY
+	
+	# only stop the theme if it's not supposed to be faded when stopped
+	# (if it's supposed to be faded, the stopping is done by the corresponding
+	# `play_music_theme()` coroutine)
+	if not theme.fade_when_stopped:
+		theme.stop()
+
+## Restarts the specified music theme from position.
+## Does nothing if music theme isn't played.
+func seek_music_theme(theme_id: MusicTheme, to_position: float) -> void:
+	_music_theme_players[theme_id].seek(to_position)
+
+## Returns [code]true[/code] if the specified music theme is playing, [code]false[/code] otherwise.
+func is_music_theme_playing(theme_id: MusicTheme) -> bool:
+	return _music_theme_players[theme_id].play_status == _PlayStatus.PLAYING
+
+## Returns [code]true[/code] if the specified music theme is playing,
+## preparing to play (fading out other music themes with lower priority),
+## or just finished playing and now all the other themes with lower priority
+## are fading back in. Returns [code]false[/code] otherwise.
+func is_music_theme_playing_or_fading(theme_id: MusicTheme) -> bool:
+	return _music_theme_players[theme_id].play_status != _PlayStatus.STOPPED
+
+## Returns [code]true[/code] if any music theme with the specified priority is playing,
+## [code]false[/code] otherwise.
+func is_music_theme_with_priority_playing(priority: PriorityLevel) -> bool:
+	var theme: _MusicThemePlayer = _last_played_music_by_priority[priority]
+	return theme != null and theme.play_status == _PlayStatus.PLAYING
+## Returns [code]true[/code] if any music theme with the specified priority is playing,
+## preparing to play (fading out other music themes with lower priority),
+## or just finished playing and now all the other themes with lower priority
+## are fading back in. Returns [code]false[/code] otherwise.
+func is_music_theme_with_priority_playing_or_fading(priority: PriorityLevel) -> bool:
+	var theme: _MusicThemePlayer = _last_played_music_by_priority[priority]
+	return theme != null and theme.play_status != _PlayStatus.STOPPED
+
+## Stops any music theme with the specified priority.
+func stop_music_theme_with_priority(priority: PriorityLevel) -> void:
+	var theme: _MusicThemePlayer = _last_played_music_by_priority[priority]
+	if theme == null:
+		return
+	var theme_id = _music_theme_players.find_key(theme)
+	assert(theme_id is MusicTheme)
+	stop_music_theme(theme_id)
+
+## Stops all currently playing music themes.
+func stop_all_music_themes() -> void:
+	for theme_id: MusicTheme in _music_theme_players:
+		stop_music_theme(theme_id)
+
+## Returns the position the music is played at, or [code]0.0[/code] if music isn't playing.
+func get_music_theme_playback_position(theme_id: MusicTheme) -> float:
+	var theme: _MusicThemePlayer = _music_theme_players[theme_id]
+	if not theme.playing:
+		return 0.0
+	return theme.get_playback_position() + AudioServer.get_time_since_last_mix()
+
+## Sets music theme for the current level.[br]
+## [param music] - music to set as a level theme.[br]
+## [param autoplay] - if [code]true[/code], start playing the music immediately.
+func set_level_music(music: AudioStream, autoplay: bool = true) -> void:
+	if music == null:
+		_music_theme_players[MusicTheme.LEVEL_THEME].stop()
+	_music_theme_players[MusicTheme.LEVEL_THEME].stream = music
+	if autoplay:
+		play_music_theme(MusicTheme.LEVEL_THEME)
+
+## Resets all music.
+func reset_music_themes() -> void:
+	var theme: _MusicThemePlayer
+	for theme_id: MusicTheme in _music_theme_players:
+		theme = _music_theme_players[theme_id]
+		theme.stop()
+		theme.play_status = _PlayStatus.STOPPED
+		theme.volume_db_proxy = 0.0
+	_last_played_music_by_priority.fill(null)
+	_reset_music_themes_flag = true
+
+func _create_music_theme(
+	stream: AudioStream,
+	priority: PriorityLevel = PriorityLevel.LEVEL_THEME,
+	fade_out_other_themes: bool = false,
+	fade_in_other_themes: bool = false,
+	fade_when_stopped: bool = false,
+	restart_level_theme: bool = false,
+	allow_replay: bool = false
+) -> _MusicThemePlayer:
+	var theme: _MusicThemePlayer = _MusicThemePlayer.new(
+		stream, priority, fade_out_other_themes, fade_in_other_themes,
+		fade_when_stopped, restart_level_theme, allow_replay)
+	add_child(theme)
+	return theme
+
+func _ready() -> void:
+	assert(MusicTheme.values() == _music_theme_players.keys())
+	_music_theme_players.make_read_only()
+	_last_played_music_by_priority.resize(PriorityLevel.size())
+
+func _physics_process(_delta: float) -> void:
+	# music playing coroutines update before this flag is set
+	# to false, as they await for `get_tree().physics_frame`
+	# which fires before `_physics_process()` is called
+	_reset_music_themes_flag = false

--- a/Scripts/Level/CharacterSelect.gd
+++ b/Scripts/Level/CharacterSelect.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 
-@export var music = preload("res://Audio/Soundtrack/10. SWD_CharacterSelect.ogg")
+@export var music: AudioStream = preload("res://Audio/Soundtrack/10. SWD_CharacterSelect.ogg")
 @export var nextZone = load("res://Scene/Zones/BaseZone.tscn")
 var selected = false
 
@@ -23,8 +23,8 @@ var action_was_pressed_last_frame = false
 
 
 func _ready():
-	Global.music.stream = music
-	Global.music.play()
+	MusicController.reset_music_themes()
+	MusicController.set_level_music(music)
 	$UI/Labels/Control/Character.text = characterLabels[characterID]
 	$UI/Labels/Control/MutliplayerMode.text = Global.MULTIMODE.find_key(Global.get_multimode())
 	if nextZone != null:

--- a/Scripts/Level/Level.gd
+++ b/Scripts/Level/Level.gd
@@ -1,6 +1,6 @@
 class_name Level extends Node2D
 
-@export var music = preload("res://Audio/Soundtrack/6. SWD_TLZa1.ogg")
+@export var music: AudioStream = preload("res://Audio/Soundtrack/6. SWD_TLZa1.ogg")
 @export var nextZone = load("res://Scene/Zones/BaseZone.tscn")
 
 @export var animal1: Animal.ANIMAL_TYPE = Animal.ANIMAL_TYPE.BIRD
@@ -46,15 +46,9 @@ func _ready():
 # used for stage starts, also used for returning from special stages
 func level_reset_data(playCard = true):
 	# music handling
-	Global.bossMusic.stop()
-	if Global.music != null:
-		if music != null:
-			Global.music.stream = music
-			Global.music.play()
-			Global.music.stream_paused = false
-		else:
-			Global.music.stop()
-			Global.music.stream = null
+	MusicController.reset_music_themes()
+	if music != null:
+		MusicController.set_level_music(music)
 	# set next zone
 	if nextZone != null:
 		Global.nextZone = nextZone

--- a/Scripts/Level/Title.gd
+++ b/Scripts/Level/Title.gd
@@ -1,13 +1,13 @@
 extends Node2D
 
-@export var music = preload("res://Audio/Soundtrack/9. SWD_TitleScreen.ogg")
+@export var music: AudioStream = preload("res://Audio/Soundtrack/9. SWD_TitleScreen.ogg")
 @export var speed = 0
 @export var nextScene = load("res://Scene/Presentation/CharacterSelect.tscn")
 var titleEnd = false
 
 func _ready():
-	Global.music.stream = music
-	Global.music.play()
+	MusicController.reset_music_themes()
+	MusicController.set_level_music(music)
 
 func _process(delta):
 	# animate cogs
@@ -21,7 +21,7 @@ func _input(event):
 	# end title on start press
 	if event.is_action_pressed("gm_pause") and !titleEnd:
 		titleEnd = true
-		if Global.music.get_playback_position() < 14.0:
-			Global.music.seek(14.0)
+		if MusicController.get_music_theme_playback_position(MusicController.MusicTheme.LEVEL_THEME) < 14.0:
+			MusicController.seek_music_theme(MusicController.MusicTheme.LEVEL_THEME, 14.0)
 		Global.main.change_scene_to_file(nextScene,"FadeOut","FadeOut",1)
 		$Celebrations.emitting = true

--- a/Scripts/Misc/HUD.gd
+++ b/Scripts/Misc/HUD.gd
@@ -103,8 +103,7 @@ func _ready():
 		# make sure level card isn't paused so it can keep playing
 		$LevelCard/CardPlayer.process_mode = PROCESS_MODE_ALWAYS
 		# temporarily let music play during pauses
-		if Global.musicParent != null:
-			Global.musicParent.process_mode = PROCESS_MODE_ALWAYS
+		MusicController.process_mode = PROCESS_MODE_ALWAYS
 		# pause game while card is playing
 		get_tree().paused = true
 		# play card animations
@@ -115,7 +114,7 @@ func _ready():
 		$LevelCard/CardPlayer.play("End")
 		# unpause the game and set previous pause mode nodes to stop on pause
 		get_tree().paused = false
-		Global.musicParent.process_mode = PROCESS_MODE_PAUSABLE
+		MusicController.process_mode = PROCESS_MODE_PAUSABLE
 		$LevelCard/CardPlayer.process_mode = PROCESS_MODE_PAUSABLE
 		# emit stage start signal
 		Global.emit_stage_start()
@@ -276,14 +275,11 @@ func _process(delta):
 		# determine if the game over is a time over (game over and time over sequences are the same but game says time)
 		if Global.levelTime >= Global.maxTime:
 			$GameOver/Game.frame = 1
+		# stop normal music tracks
+		MusicController.stop_all_music_themes()
 		# play game over animation and play music
 		$GameOver/GameOver.play("GameOver")
-		$GameOver/GameOverMusic.play()
-		# stop normal music tracks
-		Global.music.stop()
-		Global.effectTheme.stop()
-		Global.bossMusic.stop()
-		Global.life.stop()
+		MusicController.play_music_theme(MusicController.MusicTheme.GAME_OVER)
 		# wait for animation to finish
 		await $GameOver/GameOver.animation_finished
 		# reset game

--- a/Scripts/Misc/PauseManager.gd
+++ b/Scripts/Misc/PauseManager.gd
@@ -113,15 +113,14 @@ func _input(event):
 						Global.currentCheckPoint = -1
 						Global.main.change_scene_to_file(null,"FadeOut")
 						#await Global.main.scene_faded
-						Global.effectTheme.stop()
-						Global.bossMusic.stop()
-						Global.main.set_volume(0)
+						MusicController.reset_music_themes()
 			MENUS.QUIT: # quit option
 				match(option): # Options
 					0: # cancel
 						set_menu(0)
 					1: # ok
 						await get_tree().process_frame
+						MusicController.reset_music_themes()
 						Global.main.reset_game()
 
 func do_lateral_input():

--- a/Scripts/Objects/Monitor.gd
+++ b/Scripts/Objects/Monitor.gd
@@ -103,17 +103,13 @@ func destroy():
 			if !playerTouch.get("isSuper"):
 				playerTouch.shoeTime = 20
 				playerTouch.switch_physics()
-				Global.currentTheme = 1
-				Global.effectTheme.stream = Global.themes[Global.currentTheme]
-				Global.effectTheme.play()
+				MusicController.play_music_theme(MusicController.MusicTheme.SPEED_UP)
 		ITEMS.INVINCIBILITY:
 			if !playerTouch.get("isSuper"):
 				playerTouch.supTime = 20
 				playerTouch.shieldSprite.visible = false # turn off barrier for stars
 				playerTouch.get_node("InvincibilityBarrier").visible = true
-				Global.currentTheme = 0
-				Global.effectTheme.stream = Global.themes[Global.currentTheme]
-				Global.effectTheme.play()
+				MusicController.play_music_theme(MusicController.MusicTheme.INVINCIBLE)
 		ITEMS.SHIELD:
 			playerTouch.set_shield(playerTouch.SHIELDS.NORMAL)
 		ITEMS.ELEC_SHIELD:
@@ -127,10 +123,7 @@ func destroy():
 			if !playerTouch.get("isSuper"):
 				playerTouch.set_state(PlayerChar.STATES.SUPER)
 		ITEMS._1UP:
-			Global.life.play()
-			Global.lives += 1
-			Global.effectTheme.volume_db = -100
-			Global.music.volume_db = -100
+			MusicController.play_music_theme(MusicController.MusicTheme._1UP)
 		ITEMS.ROBOTNIK:
 			playerTouch.hit_player(playerTouch.global_position, Global.HAZARDS.NORMAL, 9)
 

--- a/Scripts/Objects/SpecialStageRing.gd
+++ b/Scripts/Objects/SpecialStageRing.gd
@@ -22,9 +22,7 @@ func _process(delta: float) -> void:
 		if timer < 1 and timer+delta >= 1:
 			active = false
 			
-			Global.music.stop()
-			Global.effectTheme.stop()
-			Global.bossMusic.stop()
+			MusicController.reset_music_themes()
 			$Warp.play()
 			# set next zone to current zone (this will reset when the stage is loaded back in)
 			Global.nextZone = Global.main.lastScene

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -468,17 +468,13 @@ func _process(delta):
 				isSuper = false
 				superAnimator.play("PowerDown")
 				switch_physics()
-			if Global.currentTheme == 0 and Global.effectTheme.is_playing():
-				Global.music.play()
-				Global.effectTheme.stop()
+			MusicController.stop_music_theme(MusicController.MusicTheme.INVINCIBLE)
 	
 	if (shoeTime > 0):
 		shoeTime -= delta
 		if (shoeTime <= 0):
 			switch_physics()
-			if Global.currentTheme == 1:
-				Global.music.play()
-				Global.effectTheme.stop()
+			MusicController.stop_music_theme(MusicController.MusicTheme.SPEED_UP)
 	
 	# Invulnerability timer
 	if (invTime > 0 and current_state != STATES.HIT and current_state != STATES.DIE):
@@ -549,10 +545,12 @@ func _process(delta):
 	
 	# drowning theme related
 	if playerControl == 1:
-		if !Global.drowning.playing and airTimer <= panicTime and airTimer > 0:
-			Global.drowning.play()
-		elif Global.drowning.playing and airTimer > panicTime or airTimer <= 0:
-			Global.drowning.stop()
+		if !MusicController.is_music_theme_playing(MusicController.MusicTheme.DROWNING) and \
+		   airTimer <= panicTime and airTimer > 0:
+			MusicController.play_music_theme(MusicController.MusicTheme.DROWNING)
+		elif MusicController.is_music_theme_playing(MusicController.MusicTheme.DROWNING) and \
+			 airTimer > panicTime or airTimer <= 0:
+			MusicController.stop_music_theme(MusicController.MusicTheme.DROWNING)
 	
 	# partner control timer for player 2
 	if partnerControlTime > 0:
@@ -1023,11 +1021,8 @@ func give_ring(num_rings: int = 1, play_sound: bool = true) -> void:
 	if rings >= ring1upCounter:
 		ring1upCounter += 100
 		# award 1up
-		Global.life.play()
+		MusicController.play_music_theme(MusicController.MusicTheme._1UP)
 		Global.lives += 1
-		Global.effectTheme.volume_db = -100
-		Global.bossMusic.volume_db = -100
-		Global.music.volume_db = -100
 
 
 ## Resets the player's air timer to the default air time value
@@ -1051,9 +1046,8 @@ func kill():
 		isSuper = false
 		
 	# stop special music
-	if playerControl == 1 and Global.effectTheme.is_playing():
-		Global.music.play()
-		Global.effectTheme.stop()
+	if playerControl == 1 and MusicController.is_music_theme_with_priority_playing(MusicController.PriorityLevel.EFFECT_THEME):
+		MusicController.stop_music_theme_with_priority(MusicController.PriorityLevel.EFFECT_THEME)
 			
 	# If Player 1 dies and a partner exists, initiate respawn flying from current position.
 	if playerControl == 1 and partner:
@@ -1072,8 +1066,8 @@ func kill():
 		sfx[6].play()
 	else:
 		if playerControl == 1:
-			Global.music.stop()
-			Global.effectTheme.stop()
+			MusicController.stop_music_theme(MusicController.MusicTheme.LEVEL_THEME)
+			MusicController.stop_music_theme_with_priority(MusicController.PriorityLevel.EFFECT_THEME)
 		movement = Vector2(0,0)
 		_animator.play("drown")
 		sfx[25].play()

--- a/Scripts/Player/States/SuperStart.gd
+++ b/Scripts/Player/States/SuperStart.gd
@@ -28,9 +28,7 @@ func state_process(_delta: float) -> void:
 		activated = true
 		
 		# start super theme
-		Global.currentTheme = 0
-		Global.effectTheme.stream = Global.themes[Global.currentTheme]
-		Global.effectTheme.play()
+		MusicController.play_music_theme(MusicController.MusicTheme.INVINCIBLE)
 		
 		# Start graphics changes needed to go super
 		parent.get_avatar().go_super()

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ config/icon="res://icon.png"
 
 Global="*res://Scripts/Global/Global.gd"
 GlobalFunctions="*res://Scripts/Global/GlobalFunctions.gd"
+MusicController="*res://Scripts/Global/MusicController.gd"
 
 [debug]
 


### PR DESCRIPTION
Implements a `MusicController` singleton that handles all in-game music.

Every music theme is assigned a priority. If a theme with higher priority is played, all the other themes with lower priority are temporarily muted (and optionally faded out before playing the theme with higher priority, and/or faded back in when the theme stops playing). If a music theme is muted by multiple other themes simultaneously, the muting effect is stacked.

For example, when breaking a Speed Shoes monitor, and then, after some time, a 1up monitor, `MusicController` does the following:
* Mutes the level theme.
* Starts playing the Speed Shoes theme and waits until it stops playing.
* (After breaking a 1up monitor, before the Speed Shoes theme stopped) Mutes the level theme (again, so now it has 2 stacks of muting) and the Speed Shoes theme.
* Plays the 1up jingle and waits until it stops playing.
* Gradually fades in the Speed Shoes theme and the level theme (the latter remains muted, as it still has 1 stack of muting).
* After the Speed Shoes theme stops playing, instantly unmutes the level theme.

Currently, the music priorities are (from lower to higher):
* Level music
* Effect theme (Speed Shoes, Invincibility)
* Boss theme
* Drowning theme
* 1up jingle
* Stage Clear theme
* Game Over theme