### PR TITLE
Further improvements for MusicController

### DIFF
--- a/Scripts/Level/Level.gd
+++ b/Scripts/Level/Level.gd
@@ -1,6 +1,7 @@
 class_name Level extends Node2D
 
 @export var music: AudioStream = preload("res://Audio/Soundtrack/6. SWD_TLZa1.ogg")
+@export var music_alt: AudioStream = null
 @export var nextZone = load("res://Scene/Zones/BaseZone.tscn")
 
 @export var animal1: Animal.ANIMAL_TYPE = Animal.ANIMAL_TYPE.BIRD
@@ -48,7 +49,7 @@ func level_reset_data(playCard = true):
 	# music handling
 	MusicController.reset_music_themes()
 	if music != null:
-		MusicController.set_level_music(music)
+		MusicController.set_level_music(music, music_alt)
 	# set next zone
 	if nextZone != null:
 		Global.nextZone = nextZone


### PR DESCRIPTION
This PR does the following:
* Uses `linear_to_db()` to convert from linear volume level to decibels.
This fixes the boss theme fading out too fast and leaving about half a second of silence before the level theme starts playing.
* Adds a slot for alternative level track and implements functionality for crossfading between primary and alternative tracks.