### PR TITLE
Fixes and adjustments for `MusicController`

### DIFF
--- a/Scripts/Global/MusicController.gd
+++ b/Scripts/Global/MusicController.gd
@@ -129,11 +129,11 @@ func play_music_theme(theme_id: MusicTheme) -> void:
 		return
 	
 	# pick other music themes with lower priority, so we can fade them out
-	var other_themes: Array[_MusicThemePlayer] = []
+	var lower_priority_themes: Array[_MusicThemePlayer] = []
 	for other_theme_id: MusicTheme in _music_theme_players:
 		var other_theme: _MusicThemePlayer = _music_theme_players[other_theme_id]
 		if other_theme.priority < priority:
-			other_themes.append(other_theme)
+			lower_priority_themes.append(other_theme)
 	
 	if prev_theme != null and prev_theme.play_status == _PlayStatus.PLAYING:
 		# this can be one of the following sitiations:
@@ -144,13 +144,13 @@ func play_music_theme(theme_id: MusicTheme) -> void:
 	elif not theme.fade_out_other_themes:
 		# if there's no fadeout, then we can simply mute
 		# all the other music that has lower priority
-		for other_theme: _MusicThemePlayer in other_themes:
+		for other_theme: _MusicThemePlayer in lower_priority_themes:
 			other_theme.volume_level -= 1.0
 	else:
 		# otherwise we need to gradually fade out
 		# all the other music themes with lower priority
 		theme.play_status = _PlayStatus.PRE_PLAY
-		await _fade_music_themes(other_themes, -1)
+		await _fade_music_themes(lower_priority_themes, -1)
 		# abort if `reset_music_themes()` was called
 		if _reset_music_themes_flag:
 			return
@@ -216,11 +216,11 @@ func play_music_theme(theme_id: MusicTheme) -> void:
 	
 	# fade all the other music back in
 	if not theme.fade_in_other_themes:
-		for other_theme: _MusicThemePlayer in other_themes:
+		for other_theme: _MusicThemePlayer in lower_priority_themes:
 			other_theme.volume_level += 1.0
 	else:
 		theme.play_status = _PlayStatus.POST_PLAY
-		await _fade_music_themes(other_themes, 1)
+		await _fade_music_themes(lower_priority_themes, 1)
 		# abort if `reset_music_themes()` was called
 		if _reset_music_themes_flag:
 			return

--- a/Scripts/Global/MusicController.gd
+++ b/Scripts/Global/MusicController.gd
@@ -125,6 +125,7 @@ func play_music_theme(theme_id: MusicTheme) -> void:
 		# and then we can have a quick exit
 		if prev_theme != theme:
 			prev_theme.play_status = _PlayStatus.STOPPED
+			theme.play_status = _PlayStatus.PRE_PLAY
 		return
 	
 	# pick other music themes with lower priority, so we can fade them out

--- a/Scripts/Global/MusicController.gd
+++ b/Scripts/Global/MusicController.gd
@@ -150,7 +150,7 @@ func play_music_theme(theme_id: MusicTheme) -> void:
 		# otherwise we need to gradually fade out
 		# all the other music themes with lower priority
 		theme.play_status = _PlayStatus.PRE_PLAY
-		await _fade_music_themes(lower_priority_themes, -1)
+		await _fade_music_themes(lower_priority_themes, -1.0)
 		# abort if `reset_music_themes()` was called
 		if _reset_music_themes_flag:
 			return
@@ -199,8 +199,8 @@ func play_music_theme(theme_id: MusicTheme) -> void:
 		# we need to fade out the theme
 		if theme.fade_when_stopped and theme.play_status == _PlayStatus.POST_PLAY:
 			if theme_id == MusicTheme.LEVEL_THEME:
-				_fade_music_themes([_level_theme_alt_player], -1)
-			await _fade_music_themes([theme], -1)
+				_fade_music_themes([_level_theme_alt_player], -1.0)
+			await _fade_music_themes([theme], -1.0)
 			# abort if `reset_music_themes()` was called
 			if _reset_music_themes_flag:
 				return
@@ -220,7 +220,7 @@ func play_music_theme(theme_id: MusicTheme) -> void:
 			other_theme.volume_level += 1.0
 	else:
 		theme.play_status = _PlayStatus.POST_PLAY
-		await _fade_music_themes(lower_priority_themes, 1)
+		await _fade_music_themes(lower_priority_themes, 1.0)
 		# abort if `reset_music_themes()` was called
 		if _reset_music_themes_flag:
 			return
@@ -361,7 +361,7 @@ func _create_music_theme(
 	add_child(theme)
 	return theme
 
-func _fade_music_themes(themes: Array[_MusicThemePlayer], _sign: int) -> void:
+func _fade_music_themes(themes: Array[_MusicThemePlayer], direction: float) -> void:
 	var tree: SceneTree = get_tree()
 	var physics_frame: Signal = tree.physics_frame
 	var volume_step: float
@@ -393,7 +393,7 @@ func _fade_music_themes(themes: Array[_MusicThemePlayer], _sign: int) -> void:
 		if total_volume_change >= 1.0:
 			keep_fading = false # this will be the last iteration
 			volume_step -= total_volume_change - 1.0 # compensate for the "overflow"
-		volume_step *= _sign
+		volume_step *= direction
 		# change the voulme for all specified themes
 		for theme: _MusicThemePlayer in themes:
 			theme.volume_level += volume_step


### PR DESCRIPTION
This PR does the following changes for the `MusicController` singleton:

* Fixes a bug with Speed Shoes theme not replacing Invincibility theme (and vice versa) properly.
  For example, when breaking an Invincibility monitor while the Speed Shoes theme is still playing, Level theme continued playing simultaneously with the Invincibility theme.
* Fixes a potential bug with `PRE_PLAY` not being set when replacing one music theme with another one of the same priority while the other themes with lower priority were being faded out.
It is worth noting that currently this bug can't be reproduced, as we only have one music theme (the boss music) that fades other music themes out before being played, hence "potential".
* In function `_fade_music_themes()`, changes the 2'nd argument `_sign: int` into `direction: float`.
This eliminates implicit type conversion (`int`->`float`) on each volume change step (at line `volume_step *= direction`), as well as allows for more flexibility with floating-point direction values (e.g. `0.5`, `-0.25`), which might be useful in the future.
* In `_fade_music_themes()`, renames `other_themes` into more informative `lower_priority_themes`.